### PR TITLE
[Draft] Add ISEA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ license = "MIT"
 edition = "2024"
 
 [dependencies]
+proj = "0.29"
 
 [dev-dependencies]
 


### PR DESCRIPTION
This PR aims to add a DGGSR based on Icosahedral Snyder equal-area projection. It aims to be a much simpler version of DGGRID ISEA Q2DI. The goal is to have a cell_id that can be directly used to store global DGGS raster data in 10 matrices.

- based on [OGC FMSDI Ph3 D102](https://www.youtube.com/watch?v=FWJOdMh8JQo&t=341s)
- requires PROJ 9.5 to have inverse ISEA projection (possible due to https://github.com/OSGeo/PROJ/pull/4211)
- requires https://github.com/georust/proj/pull/223 to be merged
- requires https://github.com/georust/docker-images/pull/41to be merged