### PR TITLE
Adding Apache 2.0 license to crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo_plegmata"
 version = "0.2.0"
-license = "MIT"
+license = "MIT OR Apache-2.0"
 edition = "2024"
 readme = "README.md"
 


### PR DESCRIPTION
As you can see a super small PR for the dual license as a preparation before we publish to crates.io. Interestingly Rust is made for that and you can use `AND` and `OR` logic, see [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields) right in the toml file. 