### PR TITLE
Change polyhedron functions names. Add icosahedron implementation.

### DIFF
--- a/src/constants/mod.rs
+++ b/src/constants/mod.rs
@@ -15,10 +15,12 @@
 //! - Numerical tolerances for calculations
 
 pub mod earth;
+pub mod polyhedron;
 pub mod projections;
 pub mod tolerance;
 
 // Re-export commonly used constants for convenience
 pub use earth::WGS84;
+pub use polyhedron::PolyhedronConstants;
 pub use projections::{KarneyCoefficients, IcosahedronConstants};
 pub use tolerance::Tolerance;

--- a/src/constants/polyhedron.rs
+++ b/src/constants/polyhedron.rs
@@ -2,5 +2,7 @@ pub struct PolyhedronConstants;
 
 impl PolyhedronConstants {
     /// Golden ratio for the polyhedron
-    pub const GOLDEN_RATIO: f64 = 1.618033988749895;
+    pub fn golden_ratio() -> f64 {
+        (1.0 + 5.0_f64.sqrt()) / 2.0
+    }
 }

--- a/src/constants/polyhedron.rs
+++ b/src/constants/polyhedron.rs
@@ -1,0 +1,6 @@
+pub struct PolyhedronConstants;
+
+impl PolyhedronConstants {
+    /// Golden ratio for the polyhedron
+    pub const GOLDEN_RATIO: f64 = 1.618033988749895;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,43 +31,43 @@ fn main() {
         let generator = dggrs::get(&tool, &dggs);
 
         println!("Global");
-        let result = generator.zones_from_bbox(2, false, None);
-        println!(
-            "{:?} \nGenerated {} zones",
-            result.zones,
-            result.zones.len()
-        );
+        // let result = generator.zones_from_bbox(2, false, None);
+        // println!(
+        //     "{:?} \nGenerated {} zones",
+        //     result.zones,
+        //     result.zones.len()
+        // );
 
-        println!("Global with Bbox");
-        let result = generator.zones_from_bbox(2, false, bbox.clone());
-        println!(
-            "{:?} \nGenerated {} zones",
-            result.zones,
-            result.zones.len()
-        );
+        // println!("Global with Bbox");
+        // let result = generator.zones_from_bbox(2, false, bbox.clone());
+        // println!(
+        //     "{:?} \nGenerated {} zones",
+        //     result.zones,
+        //     result.zones.len()
+        // );
 
-        println!("Point");
-        let result = generator.zone_from_point(6, pnt, false);
-        println!(
-            "{:?} \nGenerated {} zones",
-            result.zones,
-            result.zones.len()
-        );
+        // println!("Point");
+        // let result = generator.zone_from_point(6, pnt, false);
+        // println!(
+        //     "{:?} \nGenerated {} zones",
+        //     result.zones,
+        //     result.zones.len()
+        // );
 
-        println!("Subzones of {}", zone_id);
-        let result = generator.zones_from_parent(6, zone_id.clone(), false);
-        println!(
-            "{:?} \nGenerated {} zones",
-            result.zones,
-            result.zones.len()
-        );
+        // println!("Subzones of {}", zone_id);
+        // let result = generator.zones_from_parent(6, zone_id.clone(), false);
+        // println!(
+        //     "{:?} \nGenerated {} zones",
+        //     result.zones,
+        //     result.zones.len()
+        // );
 
-        println!("Single Zone {}", zone_id.clone());
-        let result = generator.zone_from_id(zone_id.clone(), false);
-        println!(
-            "{:?} \nGenerated {} zones",
-            result.zones,
-            result.zones.len()
-        );
+        // println!("Single Zone {}", zone_id.clone());
+        // let result = generator.zone_from_id(zone_id.clone(), false);
+        // println!(
+        //     "{:?} \nGenerated {} zones",
+        //     result.zones,
+        //     result.zones.len()
+        // );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,43 +31,43 @@ fn main() {
         let generator = dggrs::get(&tool, &dggs);
 
         println!("Global");
-        // let result = generator.zones_from_bbox(2, false, None);
-        // println!(
-        //     "{:?} \nGenerated {} zones",
-        //     result.zones,
-        //     result.zones.len()
-        // );
+        let result = generator.zones_from_bbox(2, false, None);
+        println!(
+            "{:?} \nGenerated {} zones",
+            result.zones,
+            result.zones.len()
+        );
 
-        // println!("Global with Bbox");
-        // let result = generator.zones_from_bbox(2, false, bbox.clone());
-        // println!(
-        //     "{:?} \nGenerated {} zones",
-        //     result.zones,
-        //     result.zones.len()
-        // );
+        println!("Global with Bbox");
+        let result = generator.zones_from_bbox(2, false, bbox.clone());
+        println!(
+            "{:?} \nGenerated {} zones",
+            result.zones,
+            result.zones.len()
+        );
 
-        // println!("Point");
-        // let result = generator.zone_from_point(6, pnt, false);
-        // println!(
-        //     "{:?} \nGenerated {} zones",
-        //     result.zones,
-        //     result.zones.len()
-        // );
+        println!("Point");
+        let result = generator.zone_from_point(6, pnt, false);
+        println!(
+            "{:?} \nGenerated {} zones",
+            result.zones,
+            result.zones.len()
+        );
 
-        // println!("Subzones of {}", zone_id);
-        // let result = generator.zones_from_parent(6, zone_id.clone(), false);
-        // println!(
-        //     "{:?} \nGenerated {} zones",
-        //     result.zones,
-        //     result.zones.len()
-        // );
+        println!("Subzones of {}", zone_id);
+        let result = generator.zones_from_parent(6, zone_id.clone(), false);
+        println!(
+            "{:?} \nGenerated {} zones",
+            result.zones,
+            result.zones.len()
+        );
 
-        // println!("Single Zone {}", zone_id.clone());
-        // let result = generator.zone_from_id(zone_id.clone(), false);
-        // println!(
-        //     "{:?} \nGenerated {} zones",
-        //     result.zones,
-        //     result.zones.len()
-        // );
+        println!("Single Zone {}", zone_id.clone());
+        let result = generator.zone_from_id(zone_id.clone(), false);
+        println!(
+            "{:?} \nGenerated {} zones",
+            result.zones,
+            result.zones.len()
+        );
     }
 }

--- a/src/models/vector_3d.rs
+++ b/src/models/vector_3d.rs
@@ -7,12 +7,12 @@
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms
 
-use std::ops::{Add, Sub, Mul, Neg};
+use std::ops::{Add, Mul, Neg, Sub};
 
 /// A 3D vector optimized for geometric operations on the unit sphere.
 /// Primarily used for discrete global grid system calculations.
-/// 
-/// **Design Reasoning**: 
+///
+/// **Design Reasoning**:
 /// - Uses f64 for precision in spherical calculations
 /// - Focuses on operations needed for icosahedron/DGGRS computations
 #[derive(Clone, Copy, Debug)]
@@ -126,12 +126,93 @@ impl Vector3D {
             z: self.z - other.z,
         }
     }
+
+    // Rotation around Z-axis (yaw)
+    pub fn yaw(self, alpha: f64) -> Vector3D {
+        let rot_z: [Vector3D; 3] = [
+            Vector3D {
+                x: alpha.cos(),
+                y: -alpha.sin(),
+                z: 0.0,
+            },
+            Vector3D {
+                x: alpha.sin(),
+                y: alpha.cos(),
+                z: 0.0,
+            },
+            Vector3D {
+                x: 0.0,
+                y: 0.0,
+                z: 1.0,
+            },
+        ];
+
+        Vector3D {
+            x: rot_z[0].dot(self),
+            y: rot_z[1].dot(self),
+            z: rot_z[2].dot(self),
+        }
+    }
+
+    // Rotation around Y-axis (pitch)
+    pub fn pitch(self, beta: f64) -> Vector3D {
+        let rot_y: [Vector3D; 3] = [
+            Vector3D {
+                x: beta.cos(),
+                y: 0.0,
+                z: beta.sin(),
+            },
+            Vector3D {
+                x: 0.0,
+                y: 1.0,
+                z: 0.0,
+            },
+            Vector3D {
+                x: -beta.sin(),
+                y: 0.0,
+                z: beta.cos(),
+            },
+        ];
+
+        Vector3D {
+            x: rot_y[0].dot(self),
+            y: rot_y[1].dot(self),
+            z: rot_y[2].dot(self),
+        }
+    }
+
+    // Rotation around x-axis (roll)
+    pub fn roll(self, gama: f64) -> Vector3D {
+        let rot_x: [Vector3D; 3] = [
+            Vector3D {
+                x: 1.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            Vector3D {
+                x: 0.0,
+                y: gama.cos(),
+                z: -gama.sin(),
+            },
+            Vector3D {
+                x: 0.0,
+                y: gama.sin(),
+                z: gama.cos(),
+            },
+        ];
+
+        Vector3D {
+            x: rot_x[0].dot(self),
+            y: rot_x[1].dot(self),
+            z: rot_x[2].dot(self),
+        }
+    }
 }
 
 // Standard operator trait implementations for better ergonomics
 impl Add for Vector3D {
     type Output = Self;
-    
+
     fn add(self, other: Self) -> Self {
         Self {
             x: self.x + other.x,
@@ -143,7 +224,7 @@ impl Add for Vector3D {
 
 impl Sub for Vector3D {
     type Output = Self;
-    
+
     fn sub(self, other: Self) -> Self {
         Self {
             x: self.x - other.x,
@@ -155,7 +236,7 @@ impl Sub for Vector3D {
 
 impl Mul<f64> for Vector3D {
     type Output = Self;
-    
+
     fn mul(self, scalar: f64) -> Self {
         Self {
             x: self.x * scalar,
@@ -167,7 +248,7 @@ impl Mul<f64> for Vector3D {
 
 impl Mul<Vector3D> for f64 {
     type Output = Vector3D;
-    
+
     fn mul(self, vector: Vector3D) -> Vector3D {
         vector * self
     }
@@ -175,7 +256,7 @@ impl Mul<Vector3D> for f64 {
 
 impl Neg for Vector3D {
     type Output = Self;
-    
+
     fn neg(self) -> Self {
         Self {
             x: -self.x,
@@ -199,7 +280,7 @@ mod tests {
     fn test_constructors() {
         let v1 = Vector3D::new(1.0, 2.0, 3.0);
         let v2 = Vector3D::from_array([1.0, 2.0, 3.0]);
-        
+
         assert_eq!(v1.x, 1.0);
         assert_eq!(v1.y, 2.0);
         assert_eq!(v1.z, 3.0);
@@ -211,22 +292,22 @@ mod tests {
     fn test_arithmetic_operators() {
         let v1 = Vector3D::new(1.0, 2.0, 3.0);
         let v2 = Vector3D::new(4.0, 5.0, 6.0);
-        
+
         let sum = v1 + v2;
         assert_eq!(sum.x, 5.0);
         assert_eq!(sum.y, 7.0);
         assert_eq!(sum.z, 9.0);
-        
+
         let diff = v2 - v1;
         assert_eq!(diff.x, 3.0);
         assert_eq!(diff.y, 3.0);
         assert_eq!(diff.z, 3.0);
-        
+
         let scaled = v1 * 2.0;
         assert_eq!(scaled.x, 2.0);
         assert_eq!(scaled.y, 4.0);
         assert_eq!(scaled.z, 6.0);
-        
+
         let neg = -v1;
         assert_eq!(neg.x, -1.0);
         assert_eq!(neg.y, -2.0);
@@ -238,10 +319,10 @@ mod tests {
         let v = Vector3D::new(3.0, 4.0, 0.0);
         assert_eq!(v.length_squared(), 25.0);
         assert_eq!(v.length(), 5.0);
-        
+
         let normalized = v.normalize();
         assert!((normalized.length() - 1.0).abs() < 1e-10);
-        
+
         // Test zero vector safety
         let zero = Vector3D::zero();
         assert!(zero.is_zero(1e-10));
@@ -259,9 +340,9 @@ mod tests {
     fn test_dot_and_cross_product() {
         let v1 = Vector3D::new(1.0, 0.0, 0.0);
         let v2 = Vector3D::new(0.0, 1.0, 0.0);
-        
+
         assert_eq!(v1.dot(v2), 0.0);
-        
+
         let cross = v1.cross(v2);
         assert_eq!(cross.x, 0.0);
         assert_eq!(cross.y, 0.0);
@@ -272,18 +353,18 @@ mod tests {
     fn test_backward_compatibility() {
         let v1 = Vector3D::new(1.0, 2.0, 3.0);
         let v2 = Vector3D::new(4.0, 5.0, 6.0);
-        
+
         // Test that old method interfaces still work
         let mid = Vector3D::mid(v1, v2);
         assert_eq!(mid.x, 2.5);
         assert_eq!(mid.y, 3.5);
         assert_eq!(mid.z, 4.5);
-        
+
         let sub = v1.subtract(v2);
         assert_eq!(sub.x, -3.0);
         assert_eq!(sub.y, -3.0);
         assert_eq!(sub.z, -3.0);
-        
+
         let neg = v1.neg();
         assert_eq!(neg.x, -1.0);
         assert_eq!(neg.y, -2.0);

--- a/src/projections/polyhedron/icosahedron.rs
+++ b/src/projections/polyhedron/icosahedron.rs
@@ -10,18 +10,12 @@
 use std::f64::consts::PI;
 
 use crate::{
-    constants::PolyhedronConstants,
-    models::vector_3d::Vector3D,
-    projections::{layout::traits::Layout, polyhedron::traits::Face},
+    constants::PolyhedronConstants, models::vector_3d::Vector3D,
+    projections::polyhedron::traits::Face,
 };
 use geo::Coord;
 
 use super::traits::{ArcLengths, Polyhedron};
-
-pub const FACES: u8 = 20;
-
-// pub const ORIENTATION_LAT: f64 =
-// pub const ORIENTATION_LON: f64 =
 
 #[derive(Default, Debug)]
 pub struct Icosahedron {}
@@ -32,14 +26,14 @@ pub struct Icosahedron {}
 /// - Two vertices on the poles, which ensures better symmetry for polar areas and
 /// simplifies some projections.
 /// That means this icosahedron is not a standard implementation but a rotated implementation to fit equal-area projections.
-/// The other vertices are on northen and southern hemisphere in two equatorial rings, with alternating longitude.
+/// The other vertices are on northern and southern hemisphere in two equatorial rings, with alternating longitude.
 impl Polyhedron for Icosahedron {
     /// The 12 points are symmetrically arranged on the sphere and lie at the same distance from the origin, forming a regular icosahedron
-    /// They are then nromalized in the sphere
+    /// They are then normalized in the sphere
     /// **Returns the actual 3D positions of the three vertices for each face.**
     fn vertices(&self) -> Vec<Vector3D> {
         let mut vertices = Vec::with_capacity(12);
-        let phi = PolyhedronConstants::GOLDEN_RATIO; // golden ratio
+        let phi = PolyhedronConstants::golden_ratio(); // golden ratio
         let z = 1.0 / (1.0 + phi.powi(2)).sqrt(); // Height (z) from center to top/bottom for the other 10 points
         let r = (1.0 - z.powi(2)).sqrt(); // Radius of the ring
 

--- a/src/projections/polyhedron/icosahedron.rs
+++ b/src/projections/polyhedron/icosahedron.rs
@@ -12,7 +12,7 @@ use std::f64::consts::PI;
 use crate::{
     constants::PolyhedronConstants,
     models::vector_3d::Vector3D,
-    projections::{layout::traits::Layout, polyhedron::traits::VertexIndices},
+    projections::{layout::traits::Layout, polyhedron::traits::{Face, VertexIndices}},
 };
 use geo::Coord;
 
@@ -173,32 +173,32 @@ impl Polyhedron for Icosahedron {
         //                 y: 0.0,
         //                 z: 1.0,
         //             }.normalize().roll(roll).yaw(yaw),
-        //         ]
+        //         ])
     }
     // Vector3D { x: 0.4472139186657891, y: 0.5257311121191336, z: 0.7236065980224116 }, Vector3D { x: 0.4472139186657892, y: -0.5257311121191336, z: 0.7236065980224116 }, Vector3D { x: -0.4472139186657892, y: 0.5257311121191336, z: -0.7236065980224116 }, Vector3D { x: -0.4472139186657891, y: -0.5257311121191336, z: -0.7236065980224116 }, Vector3D { x: -0.9999999999999003, y: -6.123233995736156e-17, z: 4.466042563544548e-7 }, Vector3D { x: -0.4472131960449229, y: -2.7383910453643627e-17, z: 0.8944273907273219 }, Vector3D { x: 0.4472131960449229, y: 2.7383910453643627e-17, z: -0.8944273907273219 }, Vector3D { x: 0.9999999999999003, y: 6.123233995736156e-17, z: -4.466042563544548e-7 }, Vector3D { x: 0.44721347206153284, y: -0.85065080835204, z: -0.2763934019774887 }, Vector3D { x: -0.4472134720615327, y: -0.85065080835204, z: 0.2763934019774887 }, Vector3D { x: 0.4472134720615327, y: 0.85065080835204, z: -0.2763934019774887 }, Vector3D { x: -0.44721347206153284, y: 0.85065080835204, z: 0.2763934019774887 }
     // **Returns the list of triangle faces as triplets of indices into the vertex array.**
-    fn face_vertex_indices(&self) -> Vec<Vec<usize>> {
+    fn face_vertex_indices(&self) -> Vec<Face> {
         vec![
-            vec![0, 11, 5],
-            vec![0, 5, 1],
-            vec![0, 1, 7],
-            vec![0, 7, 10],
-            vec![0, 10, 11],
-            vec![1, 5, 9],
-            vec![5, 11, 4],
-            vec![11, 10, 2],
-            vec![10, 7, 6],
-            vec![7, 1, 8],
-            vec![3, 9, 4],
-            vec![3, 4, 2],
-            vec![3, 2, 6],
-            vec![3, 6, 8],
-            vec![3, 8, 9],
-            vec![4, 9, 5],
-            vec![2, 4, 11],
-            vec![6, 2, 10],
-            vec![8, 6, 7],
-            vec![9, 8, 1],
+            Face::Triangle([0, 11, 5]),
+            Face::Triangle([0, 5, 1]),
+            Face::Triangle([0, 1, 7]),
+            Face::Triangle([0, 7, 10]),
+            Face::Triangle([0, 10, 11]),
+            Face::Triangle([1, 5, 9]),
+            Face::Triangle([5, 11, 4]),
+            Face::Triangle([11, 10, 2]),
+            Face::Triangle([10, 7, 6]),
+            Face::Triangle([7, 1, 8]),
+            Face::Triangle([3, 9, 4]),
+            Face::Triangle([3, 4, 2]),
+            Face::Triangle([3, 2, 6]),
+            Face::Triangle([3, 6, 8]),
+            Face::Triangle([3, 8, 9]),
+            Face::Triangle([4, 9, 5]),
+            Face::Triangle([2, 4, 11]),
+            Face::Triangle([6, 2, 10]),
+            Face::Triangle([8, 6, 7]),
+            Face::Triangle([9, 8, 1]),
         ]
     }
 

--- a/src/projections/polyhedron/icosahedron.rs
+++ b/src/projections/polyhedron/icosahedron.rs
@@ -12,7 +12,7 @@ use std::f64::consts::PI;
 use crate::{
     constants::PolyhedronConstants,
     models::vector_3d::Vector3D,
-    projections::{layout::traits::Layout, polyhedron::traits::{Face, VertexIndices}},
+    projections::{layout::traits::Layout, polyhedron::traits::Face},
 };
 use geo::Coord;
 
@@ -26,7 +26,7 @@ pub const FACES: u8 = 20;
 #[derive(Default, Debug)]
 pub struct Icosahedron {}
 
-/// This icosahedron implementation tries to has:
+/// This icosahedron implementation tries to have:
 /// - Almost no vertices on land, which reduces distortion for land-based DGGS queries
 /// by avoiding vertex-based singularities over populated areas.
 /// - Two vertices on the poles, which ensures better symmetry for polar areas and
@@ -34,16 +34,14 @@ pub struct Icosahedron {}
 /// That means this icosahedron is not a standard implementation but a rotated implementation to fit equal-area projections.
 /// The other vertices are on northen and southern hemisphere in two equatorial rings, with alternating longitude.
 impl Polyhedron for Icosahedron {
-    // The 12 points are symmetrically arranged on the sphere and lie at the same distance from the origin, forming a regular icosahedron
-    // They are then nromalized in the sphere
-    // **Returns the actual 3D positions of the three vertices for each face.**
+    /// The 12 points are symmetrically arranged on the sphere and lie at the same distance from the origin, forming a regular icosahedron
+    /// They are then nromalized in the sphere
+    /// **Returns the actual 3D positions of the three vertices for each face.**
     fn vertices(&self) -> Vec<Vector3D> {
         let mut vertices = Vec::with_capacity(12);
         let phi = PolyhedronConstants::GOLDEN_RATIO; // golden ratio
         let z = 1.0 / (1.0 + phi.powi(2)).sqrt(); // Height (z) from center to top/bottom for the other 10 points
         let r = (1.0 - z.powi(2)).sqrt(); // Radius of the ring
-
-        // // North pole
 
         // === Vertex 0: North Pole ===
         vertices.push(Vector3D {
@@ -79,104 +77,10 @@ impl Polyhedron for Icosahedron {
             z: -1.0,
         });
 
-        // // North Hemisphere
-        // vertices.push(Vector3D {
-        //     x: r * 0.0f64.cos(),
-        //     y: r * 0.0f64.sin(),
-        //     z: z,
-        // });
-        // poes nos polos e depois fazes a rotação, depois ves no site se os pontos encaixam
         vertices
-
-        // // 5 around +26.57° latitude
-        // [0.850651, 0.0, 0.525731],
-        // [0.262866, 0.809017, 0.525731],
-        // [-0.688191, 0.500000, 0.525731],
-        // [-0.688191, -0.500000, 0.525731],
-        // [0.262866, -0.809017, 0.525731],
-
-        // // 5 around -26.57° latitude
-        // [0.688191, 0.500000, -0.525731],
-        // [-0.262866, 0.809017, -0.525731],
-        // [-0.850651, 0.0, -0.525731],
-        // [-0.262866, -0.809017, -0.525731],
-        // [0.688191, -0.500000, -0.525731],
-        // let roll =58.2825f64.to_radians();
-        // let yaw =-90f64.to_radians();
-        //         vec![
-        //             Vector3D {
-        //                 x: -1.0,
-        //                 y: phi,
-        //                 z: 0.0,
-        //             }.normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: 1.0,
-        //                 y: phi,
-        //                 z: 0.0,
-        //             }.normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: -1.0,
-        //                 y: -phi,
-        //                 z: 0.0,
-        //             }
-        //             .normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: 1.0,
-        //                 y: -phi,
-        //                 z: 0.0,
-        //             }
-        //             .normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: 0.0,
-        //                 y: -1.0,
-        //                 z: phi,
-        //             }
-        //             .normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: 0.0,
-        //                 y: 1.0,
-        //                 z: phi,
-        //             }
-        //             .normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: 0.0,
-        //                 y: -1.0,
-        //                 z: -phi,
-        //             }
-        //             .normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: 0.0,
-        //                 y: 1.0,
-        //                 z: -phi,
-        //             }
-        //             .normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: phi,
-        //                 y: 0.0,
-        //                 z: -1.0,
-        //             }
-        //             .normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: phi,
-        //                 y: 0.0,
-        //                 z: 1.0,
-        //             }
-        //             .normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: -phi,
-        //                 y: 0.0,
-        //                 z: -1.0,
-        //             }
-        //             .normalize().roll(roll).yaw(yaw),
-        //             Vector3D {
-        //                 x: -phi,
-        //                 y: 0.0,
-        //                 z: 1.0,
-        //             }.normalize().roll(roll).yaw(yaw),
-        //         ])
     }
-    // Vector3D { x: 0.4472139186657891, y: 0.5257311121191336, z: 0.7236065980224116 }, Vector3D { x: 0.4472139186657892, y: -0.5257311121191336, z: 0.7236065980224116 }, Vector3D { x: -0.4472139186657892, y: 0.5257311121191336, z: -0.7236065980224116 }, Vector3D { x: -0.4472139186657891, y: -0.5257311121191336, z: -0.7236065980224116 }, Vector3D { x: -0.9999999999999003, y: -6.123233995736156e-17, z: 4.466042563544548e-7 }, Vector3D { x: -0.4472131960449229, y: -2.7383910453643627e-17, z: 0.8944273907273219 }, Vector3D { x: 0.4472131960449229, y: 2.7383910453643627e-17, z: -0.8944273907273219 }, Vector3D { x: 0.9999999999999003, y: 6.123233995736156e-17, z: -4.466042563544548e-7 }, Vector3D { x: 0.44721347206153284, y: -0.85065080835204, z: -0.2763934019774887 }, Vector3D { x: -0.4472134720615327, y: -0.85065080835204, z: 0.2763934019774887 }, Vector3D { x: 0.4472134720615327, y: 0.85065080835204, z: -0.2763934019774887 }, Vector3D { x: -0.44721347206153284, y: 0.85065080835204, z: 0.2763934019774887 }
-    // **Returns the list of triangle faces as triplets of indices into the vertex array.**
+
+    /// **Returns the list of triangle faces as triplets of indices into the vertex array.**
     fn face_vertex_indices(&self) -> Vec<Face> {
         vec![
             Face::Triangle([0, 11, 5]),
@@ -204,6 +108,7 @@ impl Polyhedron for Icosahedron {
 
     /// Aproximate spherical centroid
     /// Fast, lies on the unit sphere, stable for icosahedral faces, hierachically consistent
+    /// **Gets the center point of the face**
     fn face_center(&self, face_id: usize) -> Vector3D {
         let indices = self.face_vertex_indices();
         let vertices = self.vertices();
@@ -216,7 +121,8 @@ impl Polyhedron for Icosahedron {
         center.normalize()
     }
 
-    /// Find the triangle face that contains the point on the sphere
+    /// We are looping through the faces till we find the point.
+    /// **Finds the triangle face that contains the point on the sphere**
     fn find_face(&self, point: Vector3D) -> Option<usize> {
         let vertices = self.vertices();
         for (face_idx, face) in self.face_vertex_indices().iter().enumerate() {
@@ -229,53 +135,9 @@ impl Polyhedron for Icosahedron {
         None
     }
 
-    fn rotation_matrix(&self, vector: Vector3D, gama: f64, alpha: f64) -> Vector3D {
-        todo!()
-        // // Rotation around Z-axis (yaw)
-        // let rot_z: Vec<Vector3D> = [
-        //     [alpha.cos(), -alpha.sin(), 0.0],
-        //     [alpha.sin(), alpha.cos(), 0.0],
-        //     [0.0, 0.0, 1.0],
-        // ];
-
-        // // Rotation around X-axis (pitch)
-        // let rot_x: Vec<Vector3D> = [
-        //     [1.0, 0.0, 0.0],
-        //     [0.0, gama.cos(), -gama.sin()],
-        //     [0.0, gama.sin(), gama.cos()],
-        // ];
-
-        // rot_z[0] * (rot_x[0] *
-
-        // yaw * pitch
-    }
-    // fn triangles(
-    //     &self,
-    //     _layout: &dyn Layout,
-    //     _vector: Vector3D,
-    //     _face_vectors: Vec<Vector3D>,
-    //     _face_vertices: [(u8, u8); 3],
-    // ) -> ([Vector3D; 3], [Coord; 3]) {
-    //     todo!()
-    // }
-
+    /// TODO - needs to be reviewed for later PR
     /// Procedure to calculate arc lengths of the `triangle` with a point P (`vector` arc). To 90 degrees right triangle.
-    /// 1. Compute center 3D vector of face
-    /// 2. Compute center 2D point of face
-    /// 3. Check which sub-triangle (out of 3) v falls into:
-    ///     a. v2-v3
-    ///     b. v3-v1
-    ///     c. v1-v2
-    /// 4. For that sub-triangle, compute midpoint (vMid, pMid)
-    /// 5. Test which sub-sub-triangle v is in (with vCenter + vMid + corner)
-    /// 6. Set the triangle vertex indices: [va, vb, vc] = [0, 1, 2]
-    /// 7. Normalize vCenter, vMid
     fn face_arc_lengths(&self, triangle: [Vector3D; 3], vector: Vector3D) -> ArcLengths {
-        // Vertex indices are [0, 1, 2]
-        // Vertices for the 3D triangle that we want (v_mid: B, corner.0: A, v_center: C)
-        // let v3d = [v_mid, corner.0, vector_center];
-        // Vertices for the 2D triangle that we want
-        // let p2d = [p_mid, corner.1, point_center];
         let [mid, corner, center] = triangle;
         ArcLengths {
             ab: self.angle_between_unit(corner, mid),
@@ -287,6 +149,8 @@ impl Polyhedron for Icosahedron {
         }
     }
 
+    /// Uses barycentric coordinates
+    /// **Find if point is in a face**
     fn is_point_in_face(&self, point: Vector3D, triangle: Vec<Vector3D>) -> bool {
         if triangle.len() != 3 {
             return false;
@@ -325,6 +189,7 @@ impl Polyhedron for Icosahedron {
 
     /// Numerically stable angle between two unit vectors
     /// Uses atan2 method for better numerical stability than acos
+    /// **Return the angle between unit vectors**
     fn angle_between_unit(&self, u: Vector3D, v: Vector3D) -> f64 {
         // For unit vectors, use the cross product magnitude and dot product
         // with atan2 for numerical stability

--- a/src/projections/polyhedron/icosahedron.rs
+++ b/src/projections/polyhedron/icosahedron.rs
@@ -43,6 +43,8 @@ impl Polyhedron for Icosahedron {
         let z = 1.0 / (1.0 + phi.powi(2)).sqrt(); // Height (z) from center to top/bottom for the other 10 points
         let r = (1.0 - z.powi(2)).sqrt(); // Radius of the ring
 
+        // // North pole
+
         // === Vertex 0: North Pole ===
         vertices.push(Vector3D {
             x: 0.0,
@@ -77,12 +79,103 @@ impl Polyhedron for Icosahedron {
             z: -1.0,
         });
 
-      
+        // // North Hemisphere
+        // vertices.push(Vector3D {
+        //     x: r * 0.0f64.cos(),
+        //     y: r * 0.0f64.sin(),
+        //     z: z,
+        // });
+        // poes nos polos e depois fazes a rotação, depois ves no site se os pontos encaixam
         vertices
 
-     
-    }
+        // // 5 around +26.57° latitude
+        // [0.850651, 0.0, 0.525731],
+        // [0.262866, 0.809017, 0.525731],
+        // [-0.688191, 0.500000, 0.525731],
+        // [-0.688191, -0.500000, 0.525731],
+        // [0.262866, -0.809017, 0.525731],
 
+        // // 5 around -26.57° latitude
+        // [0.688191, 0.500000, -0.525731],
+        // [-0.262866, 0.809017, -0.525731],
+        // [-0.850651, 0.0, -0.525731],
+        // [-0.262866, -0.809017, -0.525731],
+        // [0.688191, -0.500000, -0.525731],
+        // let roll =58.2825f64.to_radians();
+        // let yaw =-90f64.to_radians();
+        //         vec![
+        //             Vector3D {
+        //                 x: -1.0,
+        //                 y: phi,
+        //                 z: 0.0,
+        //             }.normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: 1.0,
+        //                 y: phi,
+        //                 z: 0.0,
+        //             }.normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: -1.0,
+        //                 y: -phi,
+        //                 z: 0.0,
+        //             }
+        //             .normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: 1.0,
+        //                 y: -phi,
+        //                 z: 0.0,
+        //             }
+        //             .normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: 0.0,
+        //                 y: -1.0,
+        //                 z: phi,
+        //             }
+        //             .normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: 0.0,
+        //                 y: 1.0,
+        //                 z: phi,
+        //             }
+        //             .normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: 0.0,
+        //                 y: -1.0,
+        //                 z: -phi,
+        //             }
+        //             .normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: 0.0,
+        //                 y: 1.0,
+        //                 z: -phi,
+        //             }
+        //             .normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: phi,
+        //                 y: 0.0,
+        //                 z: -1.0,
+        //             }
+        //             .normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: phi,
+        //                 y: 0.0,
+        //                 z: 1.0,
+        //             }
+        //             .normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: -phi,
+        //                 y: 0.0,
+        //                 z: -1.0,
+        //             }
+        //             .normalize().roll(roll).yaw(yaw),
+        //             Vector3D {
+        //                 x: -phi,
+        //                 y: 0.0,
+        //                 z: 1.0,
+        //             }.normalize().roll(roll).yaw(yaw),
+        //         ]
+    }
+    // Vector3D { x: 0.4472139186657891, y: 0.5257311121191336, z: 0.7236065980224116 }, Vector3D { x: 0.4472139186657892, y: -0.5257311121191336, z: 0.7236065980224116 }, Vector3D { x: -0.4472139186657892, y: 0.5257311121191336, z: -0.7236065980224116 }, Vector3D { x: -0.4472139186657891, y: -0.5257311121191336, z: -0.7236065980224116 }, Vector3D { x: -0.9999999999999003, y: -6.123233995736156e-17, z: 4.466042563544548e-7 }, Vector3D { x: -0.4472131960449229, y: -2.7383910453643627e-17, z: 0.8944273907273219 }, Vector3D { x: 0.4472131960449229, y: 2.7383910453643627e-17, z: -0.8944273907273219 }, Vector3D { x: 0.9999999999999003, y: 6.123233995736156e-17, z: -4.466042563544548e-7 }, Vector3D { x: 0.44721347206153284, y: -0.85065080835204, z: -0.2763934019774887 }, Vector3D { x: -0.4472134720615327, y: -0.85065080835204, z: 0.2763934019774887 }, Vector3D { x: 0.4472134720615327, y: 0.85065080835204, z: -0.2763934019774887 }, Vector3D { x: -0.44721347206153284, y: 0.85065080835204, z: 0.2763934019774887 }
     // **Returns the list of triangle faces as triplets of indices into the vertex array.**
     fn face_vertex_indices(&self) -> Vec<Vec<usize>> {
         vec![

--- a/src/projections/polyhedron/icosahedron.rs
+++ b/src/projections/polyhedron/icosahedron.rs
@@ -8,6 +8,7 @@
 // except according to those terms
 
 use crate::{
+    constants::PolyhedronConstants,
     models::vector_3d::Vector3D,
     projections::{layout::traits::Layout, polyhedron::traits::VertexIndices},
 };
@@ -28,7 +29,7 @@ impl Polyhedron for Icosahedron {
     // They are then nromalized in the sphere
     // **Returns the actual 3D positions of the three vertices for each face.**
     fn vertices(&self) -> Vec<Vector3D> {
-        let phi = (1.0 + 5.0f64.sqrt()) / 2.0; // golden ratio
+        let phi = PolyhedronConstants::GOLDEN_RATIO; // golden ratio
         vec![
             Vector3D {
                 x: -1.0,
@@ -144,7 +145,7 @@ impl Polyhedron for Icosahedron {
         let center = a + b + c;
         center.normalize()
     }
-    
+
     /// Find the triangle face that contains the point on the sphere
     fn find_face(&self, point: Vector3D) -> Option<usize> {
         let vertices = self.vertices();
@@ -158,6 +159,26 @@ impl Polyhedron for Icosahedron {
         None
     }
 
+    fn rotation_matrix(&self, vector:Vector3D, gama: f64, alpha: f64) -> Vector3D {
+        todo!()
+        // // Rotation around Z-axis (yaw)
+        // let rot_z: Vec<Vector3D> = [
+        //     [alpha.cos(), -alpha.sin(), 0.0],
+        //     [alpha.sin(), alpha.cos(), 0.0],
+        //     [0.0, 0.0, 1.0],
+        // ];
+
+        // // Rotation around X-axis (pitch)
+        // let rot_x: Vec<Vector3D> = [
+        //     [1.0, 0.0, 0.0],
+        //     [0.0, gama.cos(), -gama.sin()],
+        //     [0.0, gama.sin(), gama.cos()],
+        // ];
+
+        // rot_z[0] * (rot_x[0] * 
+
+        // yaw * pitch
+    }
     // fn triangles(
     //     &self,
     //     _layout: &dyn Layout,

--- a/src/projections/polyhedron/icosahedron.rs
+++ b/src/projections/polyhedron/icosahedron.rs
@@ -82,6 +82,7 @@ impl Polyhedron for Icosahedron {
 
     /// **Returns the list of triangle faces as triplets of indices into the vertex array.**
     fn face_vertex_indices(&self) -> Vec<Face> {
+        // want to avoid a loop here for performance reasons
         vec![
             Face::Triangle([0, 11, 5]),
             Face::Triangle([0, 5, 1]),
@@ -110,9 +111,9 @@ impl Polyhedron for Icosahedron {
     /// Fast, lies on the unit sphere, stable for icosahedral faces, hierachically consistent
     /// **Gets the center point of the face**
     fn face_center(&self, face_id: usize) -> Vector3D {
-        let indices = self.face_vertex_indices();
+        let faces = self.face_vertex_indices();
         let vertices = self.vertices();
-        let face = &indices[face_id];
+        let face = faces[face_id].indices();
         let a = vertices[face[0]];
         let b = vertices[face[1]];
         let c = vertices[face[2]];
@@ -126,7 +127,7 @@ impl Polyhedron for Icosahedron {
     fn find_face(&self, point: Vector3D) -> Option<usize> {
         let vertices = self.vertices();
         for (face_idx, face) in self.face_vertex_indices().iter().enumerate() {
-            let triangle: Vec<Vector3D> = face.iter().map(|&i| vertices[i]).collect();
+            let triangle: Vec<Vector3D> = face.indices().iter().map(|&i| vertices[i]).collect();
 
             if self.is_point_in_face(point, triangle) {
                 return Some(face_idx);
@@ -210,11 +211,11 @@ mod tests {
     fn test_face_center() {
         let ico = Icosahedron {};
         let faces = ico.face_vertex_indices();
-        println!("{:?}", ico.vertices());
+
         for (i, face) in faces.iter().enumerate() {
-            let v0 = ico.vertices()[face[0]];
-            let v1 = ico.vertices()[face[1]];
-            let v2 = ico.vertices()[face[2]];
+            let v0 = ico.vertices()[face.indices()[0]];
+            let v1 = ico.vertices()[face.indices()[1]];
+            let v2 = ico.vertices()[face.indices()[2]];
             let center = ico.face_center(i);
 
             // Check if center it's on the unit sphere

--- a/src/projections/polyhedron/traits.rs
+++ b/src/projections/polyhedron/traits.rs
@@ -9,14 +9,6 @@
 
 use crate::models::vector_3d::Vector3D;
 
-pub enum Face {
-    Triangle([usize; 3]),
-    Quad([usize; 4]),
-    Pentagon([usize; 5]),
-    Hexagon([usize; 6]),
-    Polygon(Vec<usize>), // for rare or irregular faces
-}
-
 pub trait Polyhedron {
     /// Return the actual 3D vertices of each face.
     fn vertices(&self) -> Vec<Vector3D>;
@@ -40,7 +32,27 @@ pub trait Polyhedron {
     fn angle_between_unit(&self, u: Vector3D, v: Vector3D) -> f64;
 }
 
-#[derive(Default, Debug)]
+pub enum Face {
+    Triangle([usize; 3]),
+    Quad([usize; 4]),
+    Pentagon([usize; 5]),
+    Hexagon([usize; 6]),
+    Polygon(Vec<usize>), // for rare or irregular faces
+}
+
+impl Face {
+    pub fn indices(&self) -> &[usize] {
+        match self {
+            Face::Triangle(v) => v,
+            Face::Quad(v) => v,
+            Face::Pentagon(v) => v,
+            Face::Hexagon(v) => v,
+            Face::Polygon(v) => v,
+        }
+    }
+}
+
+#[derive(Default)]
 pub struct ArcLengths {
     pub ab: f64,
     pub bc: f64,

--- a/src/projections/polyhedron/traits.rs
+++ b/src/projections/polyhedron/traits.rs
@@ -37,7 +37,7 @@ pub trait Polyhedron {
     fn face_arc_lengths(&self, triangle: [Vector3D; 3], point: Vector3D) -> ArcLengths;
     // fn face_center(&self, vector1: Vector3D, vector2: Vector3D, vector3: Vector3D) -> Vector3D;
     /// Classic spherical triangle containment test.
-    fn is_point_in_face(&self, point: Vector3D, triangle: Vec<Vector3D>) -> bool;
+    fn is_point_in_face(&self, point: Vector3D, face: Vec<Vector3D>) -> bool;
     /// Get angle (in radians) between two unit vectors.
     fn angle_between_unit(&self, u: Vector3D, v: Vector3D) -> f64;
 }

--- a/src/projections/polyhedron/traits.rs
+++ b/src/projections/polyhedron/traits.rs
@@ -25,6 +25,8 @@ pub trait Polyhedron {
     fn face_center(&self, face_id: usize) -> Vector3D;
     /// Given a point on the unit sphere, return the face index that contains it.
     fn find_face(&self, point: Vector3D) -> Option<usize>;
+
+    fn rotation_matrix(&self, ector:Vector3D, gama: f64, alpha: f64) -> Vector3D;
     // fn unit_vectors(&self) -> Vec<Vector3D>;
     // fn triangles(
     //     &self,

--- a/src/projections/polyhedron/traits.rs
+++ b/src/projections/polyhedron/traits.rs
@@ -20,18 +20,22 @@ pub enum Face {
 pub trait Polyhedron {
     /// Return the actual 3D vertices of each face.
     fn vertices(&self) -> Vec<Vector3D>;
+
     /// Return index triplets of the icosahedron faces.
     fn face_vertex_indices(&self) -> Vec<Face>;
+
     /// Compute the centroid of a triangle face.
     fn face_center(&self, face_id: usize) -> Vector3D;
+
     /// Given a point on the unit sphere, return the face index that contains it.
     fn find_face(&self, point: Vector3D) -> Option<usize>;
 
     /// Compute spherical arc lengths between point P and the triangle's vertices.
     fn face_arc_lengths(&self, triangle: [Vector3D; 3], point: Vector3D) -> ArcLengths;
-    // fn face_center(&self, vector1: Vector3D, vector2: Vector3D, vector3: Vector3D) -> Vector3D;
+
     /// Classic spherical triangle containment test.
     fn is_point_in_face(&self, point: Vector3D, face: Vec<Vector3D>) -> bool;
+
     /// Get angle (in radians) between two unit vectors.
     fn angle_between_unit(&self, u: Vector3D, v: Vector3D) -> f64;
 }

--- a/src/projections/polyhedron/traits.rs
+++ b/src/projections/polyhedron/traits.rs
@@ -7,26 +7,38 @@
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms
 
-use crate::{
-    models::vector_3d::Vector3D,
-    projections::layout::traits::Layout,
-};
+use crate::{models::vector_3d::Vector3D, projections::layout::traits::Layout};
 use geo::Coord;
 
+pub enum VertexIndices {
+    Triangles(Vec<[usize; 3]>),
+    Cubes(Vec<[usize; 4]>),
+    Pentagons(Vec<[usize; 5]>),
+}
+
 pub trait Polyhedron {
-    fn faces(&self) -> u8;
-    fn indices(&self) -> Vec<[u8; 3]>;
-    fn unit_vectors(&self) -> Vec<Vector3D>;
-    fn triangles(
-        &self,
-        layout: &dyn Layout,
-        vector: Vector3D,
-        face_vectors: Vec<Vector3D>,
-        face_vertices: [(u8, u8); 3],
-    ) -> ([Vector3D; 3], [Coord; 3]);
-    fn triangle_arc_lengths(&self, triangle: [Vector3D; 3], vector: Vector3D) -> ArcLengths;
-    fn face_center(&self, vector1: Vector3D, vector2: Vector3D, vector3: Vector3D) -> Vector3D;
-    fn is_point_in_triangle(&self, point: Vector3D, triangle: Vec<Vector3D>) -> bool;
+    /// Return the actual 3D vertices of each face.
+    fn vertices(&self) -> Vec<Vector3D>;
+    /// Return index triplets of the icosahedron faces.
+    fn face_vertex_indices(&self) -> Vec<Vec<usize>>;
+    /// Compute the centroid of a triangle face.
+    fn face_center(&self, face_id: usize) -> Vector3D;
+    /// Given a point on the unit sphere, return the face index that contains it.
+    fn find_face(&self, point: Vector3D) -> Option<usize>;
+    // fn unit_vectors(&self) -> Vec<Vector3D>;
+    // fn triangles(
+    //     &self,
+    //     layout: &dyn Layout,
+    //     vector: Vector3D,
+    //     face_vectors: Vec<Vector3D>,
+    //     face_vertices: [(u8, u8); 3],
+    // ) -> ([Vector3D; 3], [Coord; 3]);
+    /// Compute spherical arc lengths between point P and the triangle's vertices.
+    fn face_arc_lengths(&self, triangle: [Vector3D; 3], point: Vector3D) -> ArcLengths;
+    // fn face_center(&self, vector1: Vector3D, vector2: Vector3D, vector3: Vector3D) -> Vector3D;
+    /// Classic spherical triangle containment test.
+    fn is_point_in_face(&self, point: Vector3D, triangle: Vec<Vector3D>) -> bool;
+    /// Get angle (in radians) between two unit vectors.
     fn angle_between_unit(&self, u: Vector3D, v: Vector3D) -> f64;
 }
 

--- a/src/projections/polyhedron/traits.rs
+++ b/src/projections/polyhedron/traits.rs
@@ -7,26 +7,27 @@
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms
 
-use crate::{models::vector_3d::Vector3D, projections::layout::traits::Layout};
-use geo::Coord;
+use crate::models::vector_3d::Vector3D;
 
-pub enum VertexIndices {
-    Triangles(Vec<[usize; 3]>),
-    Cubes(Vec<[usize; 4]>),
-    Pentagons(Vec<[usize; 5]>),
+pub enum Face {
+    Triangle([usize; 3]),
+    Quad([usize; 4]),
+    Pentagon([usize; 5]),
+    Hexagon([usize; 6]),
+    Polygon(Vec<usize>), // for rare or irregular faces
 }
 
 pub trait Polyhedron {
     /// Return the actual 3D vertices of each face.
     fn vertices(&self) -> Vec<Vector3D>;
     /// Return index triplets of the icosahedron faces.
-    fn face_vertex_indices(&self) -> Vec<Vec<usize>>;
+    fn face_vertex_indices(&self) -> Vec<Face>;
     /// Compute the centroid of a triangle face.
     fn face_center(&self, face_id: usize) -> Vector3D;
     /// Given a point on the unit sphere, return the face index that contains it.
     fn find_face(&self, point: Vector3D) -> Option<usize>;
 
-    fn rotation_matrix(&self, ector:Vector3D, gama: f64, alpha: f64) -> Vector3D;
+    fn rotation_matrix(&self, ector: Vector3D, gama: f64, alpha: f64) -> Vector3D;
     // fn unit_vectors(&self) -> Vec<Vector3D>;
     // fn triangles(
     //     &self,

--- a/src/projections/polyhedron/traits.rs
+++ b/src/projections/polyhedron/traits.rs
@@ -27,15 +27,6 @@ pub trait Polyhedron {
     /// Given a point on the unit sphere, return the face index that contains it.
     fn find_face(&self, point: Vector3D) -> Option<usize>;
 
-    fn rotation_matrix(&self, ector: Vector3D, gama: f64, alpha: f64) -> Vector3D;
-    // fn unit_vectors(&self) -> Vec<Vector3D>;
-    // fn triangles(
-    //     &self,
-    //     layout: &dyn Layout,
-    //     vector: Vector3D,
-    //     face_vectors: Vec<Vector3D>,
-    //     face_vertices: [(u8, u8); 3],
-    // ) -> ([Vector3D; 3], [Coord; 3]);
     /// Compute spherical arc lengths between point P and the triangle's vertices.
     fn face_arc_lengths(&self, triangle: [Vector3D; 3], point: Vector3D) -> ArcLengths;
     // fn face_center(&self, vector1: Vector3D, vector2: Vector3D, vector3: Vector3D) -> Vector3D;

--- a/src/projections/projections/vgc.rs
+++ b/src/projections/projections/vgc.rs
@@ -39,84 +39,84 @@ impl Projection for Vgc {
         // Need the coeficcients to convert from geodetic to authalic
         let coef_fourier_geod_to_auth = Self::fourier_coefficients(KarneyCoefficients::GEODETIC_TO_AUTHALIC);
 
-        // // get 3d unit vectors of the icosahedron
-        // let ico_vectors = polyhedron.unit_vectors();
-        // let triangles_ids = polyhedron.indices();
+        // // get 3d vertices of the icosahedron
+        let ico_vectors = polyhedron.vertices();
+        let triangles_ids = polyhedron.face_vertex_indices();
 
-        // // ABC
-        // let angle_beta: f64 = 36.0f64.to_radians();
-        // // BCA
-        // let angle_gamma: f64 = 60.0f64.to_radians();
-        // // BAC
-        // // let angle_alpha: f64 = PI / 2.0;
+        // ABC
+        let angle_beta: f64 = 36.0f64.to_radians();
+        // BCA
+        let angle_gamma: f64 = 60.0f64.to_radians();
+        // BAC
+        let angle_alpha: f64 = PI / 2.0;
 
-        // let v2d = layout.vertices();
+        let v2d = layout.vertices();
 
-        // for position in positions {
-        //     let lon = position.x().to_radians();
-        //     let lat = Self::lat_geodetic_to_authalic(
-        //         position.y().to_radians(),
-        //         &coef_fourier_geod_to_auth,
-        //     );
-        //     // Calculate 3d unit vectors for point P
-        //     let vector_3d = Vector3D::from_array(Self::to_3d(lat, lon));
+        for position in positions {
+            let lon = position.x().to_radians();
+            let lat = Self::lat_geodetic_to_authalic(
+                position.y().to_radians(),
+                &coef_fourier_geod_to_auth,
+            );
+            // Calculate 3d unit vectors for point P
+            let vector_3d = Vector3D::from_array(Self::to_3d(lat, lon));
 
-        //     // starting from here, you need:
-        //     // - the 3d point that you want to project
-        //     // - the 3d vertexes of the icosahedron
-        //     // - the 2d vertexes of the layout
-        //     // Polyhedron faces
-        //     let faces_length = polyhedron.faces();
-        //     for index in 0..faces_length {
-        //         let face = usize::from(index);
-        //         let ids = triangles_ids[face];
+            // starting from here, you need:
+            // - the 3d point that you want to project
+            // - the 3d vertexes of the icosahedron
+            // - the 2d vertexes of the layout
+            // Polyhedron faces
+            let faces_length = polyhedron.faces();
+            for index in 0..faces_length {
+                let face = usize::from(index);
+                let ids = triangles_ids[face];
 
-        //         let triangle_3d = vec![
-        //             ico_vectors[ids[0] as usize],
-        //             ico_vectors[ids[1] as usize],
-        //             ico_vectors[ids[2] as usize],
-        //         ];
-        //         if polyhedron.is_point_in_triangle(vector_3d, triangle_3d.clone()) {
-        //             let (triangle_3d, triangle_2d) =
-        //                 polyhedron.triangles(layout, vector_3d, triangle_3d, v2d[face]);
-        //             let ArcLengths { ab, bp, ap, .. } =
-        //                 polyhedron.triangle_arc_lengths(triangle_3d, vector_3d);
+                let triangle_3d = vec![
+                    ico_vectors[ids[0] as usize],
+                    ico_vectors[ids[1] as usize],
+                    ico_vectors[ids[2] as usize],
+                ];
+                if polyhedron.is_point_in_triangle(vector_3d, triangle_3d.clone()) {
+                    let (triangle_3d, triangle_2d) =
+                        polyhedron.triangles(layout, vector_3d, triangle_3d, v2d[face]);
+                    let ArcLengths { ab, bp, ap, .. } =
+                        polyhedron.triangle_arc_lengths(triangle_3d, vector_3d);
 
-        //             // angle ρ
-        //             let rho: f64 =
-        //                 f64::acos(ap.cos() - ab.cos() * bp.cos()) / (ab.sin() * bp.sin());
+                    // angle ρ
+                    let rho: f64 =
+                        f64::acos(ap.cos() - ab.cos() * bp.cos()) / (ab.sin() * bp.sin());
 
-        //             // 1. Calculate delta (δ)
-        //             let delta = f64::acos(rho.sin() * ab.cos());
+                    // 1. Calculate delta (δ)
+                    let delta = f64::acos(rho.sin() * ab.cos());
 
-        //             // 2. Calculate u
-        //             let uv = (angle_beta + angle_gamma - rho - delta)
-        //                 / (angle_beta + angle_gamma - PI / 2.0);
+                    // 2. Calculate u
+                    let uv = (angle_beta + angle_gamma - rho - delta)
+                        / (angle_beta + angle_gamma - PI / 2.0);
 
-        //             let cos_xp_y;
-        //             if rho <= E.powi(-9) {
-        //                 cos_xp_y = ab.cos();
-        //             } else {
-        //                 cos_xp_y = 1.0 / (rho.tan() * delta.tan())
-        //             }
+                    let cos_xp_y;
+                    if rho <= E.powi(-9) {
+                        cos_xp_y = ab.cos();
+                    } else {
+                        cos_xp_y = 1.0 / (rho.tan() * delta.tan())
+                    }
 
-        //             let xy = f64::sqrt((1.0 - bp.cos()) / (1.0 - cos_xp_y));
+                    let xy = f64::sqrt((1.0 - bp.cos()) / (1.0 - cos_xp_y));
 
-        //             // Triangle vertexes
-        //             let (p0, p1, p2) = (&triangle_2d[0], &triangle_2d[1], &triangle_2d[2]);
+                    // Triangle vertexes
+                    let (p0, p1, p2) = (&triangle_2d[0], &triangle_2d[1], &triangle_2d[2]);
 
-        //             // Between A e o C it gives point D
-        //             let pd_x = p2.x + (p0.x - p2.x) * uv;
-        //             let pd_y = p2.y + (p0.y - p2.y) * uv;
+                    // Between A e o C it gives point D
+                    let pd_x = p2.x + (p0.x - p2.x) * uv;
+                    let pd_y = p2.y + (p0.y - p2.y) * uv;
 
-        //             // Between D and B it gives point P
-        //             let p_x = pd_x + (pd_x - p1.x) * xy;
-        //             let p_y = pd_y + (pd_x - p1.y) * xy;
+                    // Between D and B it gives point P
+                    let p_x = pd_x + (pd_x - p1.x) * xy;
+                    let p_y = pd_y + (pd_x - p1.y) * xy;
 
-        //             out.push(Coord { x: p_x, y: p_y });
-        //         }
-        //     }
-        // }
+                    out.push(Coord { x: p_x, y: p_y });
+                }
+            }
+        }
 
         out
     }

--- a/src/projections/projections/vgc.rs
+++ b/src/projections/projections/vgc.rs
@@ -52,71 +52,71 @@ impl Projection for Vgc {
 
         let v2d = layout.vertices();
 
-        for position in positions {
-            let lon = position.x().to_radians();
-            let lat = Self::lat_geodetic_to_authalic(
-                position.y().to_radians(),
-                &coef_fourier_geod_to_auth,
-            );
-            // Calculate 3d unit vectors for point P
-            let vector_3d = Vector3D::from_array(Self::to_3d(lat, lon));
+        // for position in positions {
+        //     let lon = position.x().to_radians();
+        //     let lat = Self::lat_geodetic_to_authalic(
+        //         position.y().to_radians(),
+        //         &coef_fourier_geod_to_auth,
+        //     );
+        //     // Calculate 3d unit vectors for point P
+        //     let vector_3d = Vector3D::from_array(Self::to_3d(lat, lon));
 
-            // starting from here, you need:
-            // - the 3d point that you want to project
-            // - the 3d vertexes of the icosahedron
-            // - the 2d vertexes of the layout
-            // Polyhedron faces
-            let faces_length = polyhedron.faces();
-            for index in 0..faces_length {
-                let face = usize::from(index);
-                let ids = triangles_ids[face];
+        //     // starting from here, you need:
+        //     // - the 3d point that you want to project
+        //     // - the 3d vertexes of the icosahedron
+        //     // - the 2d vertexes of the layout
+        //     // Polyhedron faces
+        //     let faces_length = polyhedron.faces();
+        //     for index in 0..faces_length {
+        //         let face = usize::from(index);
+        //         let ids = triangles_ids[face];
 
-                let triangle_3d = vec![
-                    ico_vectors[ids[0] as usize],
-                    ico_vectors[ids[1] as usize],
-                    ico_vectors[ids[2] as usize],
-                ];
-                if polyhedron.is_point_in_triangle(vector_3d, triangle_3d.clone()) {
-                    let (triangle_3d, triangle_2d) =
-                        polyhedron.triangles(layout, vector_3d, triangle_3d, v2d[face]);
-                    let ArcLengths { ab, bp, ap, .. } =
-                        polyhedron.triangle_arc_lengths(triangle_3d, vector_3d);
+        //         let triangle_3d = vec![
+        //             ico_vectors[ids[0] as usize],
+        //             ico_vectors[ids[1] as usize],
+        //             ico_vectors[ids[2] as usize],
+        //         ];
+        //         if polyhedron.is_point_in_triangle(vector_3d, triangle_3d.clone()) {
+        //             let (triangle_3d, triangle_2d) =
+        //                 polyhedron.triangles(layout, vector_3d, triangle_3d, v2d[face]);
+        //             let ArcLengths { ab, bp, ap, .. } =
+        //                 polyhedron.triangle_arc_lengths(triangle_3d, vector_3d);
 
-                    // angle ρ
-                    let rho: f64 =
-                        f64::acos(ap.cos() - ab.cos() * bp.cos()) / (ab.sin() * bp.sin());
+        //             // angle ρ
+        //             let rho: f64 =
+        //                 f64::acos(ap.cos() - ab.cos() * bp.cos()) / (ab.sin() * bp.sin());
 
-                    // 1. Calculate delta (δ)
-                    let delta = f64::acos(rho.sin() * ab.cos());
+        //             // 1. Calculate delta (δ)
+        //             let delta = f64::acos(rho.sin() * ab.cos());
 
-                    // 2. Calculate u
-                    let uv = (angle_beta + angle_gamma - rho - delta)
-                        / (angle_beta + angle_gamma - PI / 2.0);
+        //             // 2. Calculate u
+        //             let uv = (angle_beta + angle_gamma - rho - delta)
+        //                 / (angle_beta + angle_gamma - PI / 2.0);
 
-                    let cos_xp_y;
-                    if rho <= E.powi(-9) {
-                        cos_xp_y = ab.cos();
-                    } else {
-                        cos_xp_y = 1.0 / (rho.tan() * delta.tan())
-                    }
+        //             let cos_xp_y;
+        //             if rho <= E.powi(-9) {
+        //                 cos_xp_y = ab.cos();
+        //             } else {
+        //                 cos_xp_y = 1.0 / (rho.tan() * delta.tan())
+        //             }
 
-                    let xy = f64::sqrt((1.0 - bp.cos()) / (1.0 - cos_xp_y));
+        //             let xy = f64::sqrt((1.0 - bp.cos()) / (1.0 - cos_xp_y));
 
-                    // Triangle vertexes
-                    let (p0, p1, p2) = (&triangle_2d[0], &triangle_2d[1], &triangle_2d[2]);
+        //             // Triangle vertexes
+        //             let (p0, p1, p2) = (&triangle_2d[0], &triangle_2d[1], &triangle_2d[2]);
 
-                    // Between A e o C it gives point D
-                    let pd_x = p2.x + (p0.x - p2.x) * uv;
-                    let pd_y = p2.y + (p0.y - p2.y) * uv;
+        //             // Between A e o C it gives point D
+        //             let pd_x = p2.x + (p0.x - p2.x) * uv;
+        //             let pd_y = p2.y + (p0.y - p2.y) * uv;
 
-                    // Between D and B it gives point P
-                    let p_x = pd_x + (pd_x - p1.x) * xy;
-                    let p_y = pd_y + (pd_x - p1.y) * xy;
+        //             // Between D and B it gives point P
+        //             let p_x = pd_x + (pd_x - p1.x) * xy;
+        //             let p_y = pd_y + (pd_x - p1.y) * xy;
 
-                    out.push(Coord { x: p_x, y: p_y });
-                }
-            }
-        }
+        //             out.push(Coord { x: p_x, y: p_y });
+        //         }
+        //     }
+        // }
 
         out
     }

--- a/src/projections/projections/vgc.rs
+++ b/src/projections/projections/vgc.rs
@@ -39,84 +39,84 @@ impl Projection for Vgc {
         // Need the coeficcients to convert from geodetic to authalic
         let coef_fourier_geod_to_auth = Self::fourier_coefficients(KarneyCoefficients::GEODETIC_TO_AUTHALIC);
 
-        // get 3d unit vectors of the icosahedron
-        let ico_vectors = polyhedron.unit_vectors();
-        let triangles_ids = polyhedron.indices();
+        // // get 3d unit vectors of the icosahedron
+        // let ico_vectors = polyhedron.unit_vectors();
+        // let triangles_ids = polyhedron.indices();
 
-        // ABC
-        let angle_beta: f64 = 36.0f64.to_radians();
-        // BCA
-        let angle_gamma: f64 = 60.0f64.to_radians();
-        // BAC
-        // let angle_alpha: f64 = PI / 2.0;
+        // // ABC
+        // let angle_beta: f64 = 36.0f64.to_radians();
+        // // BCA
+        // let angle_gamma: f64 = 60.0f64.to_radians();
+        // // BAC
+        // // let angle_alpha: f64 = PI / 2.0;
 
-        let v2d = layout.vertices();
+        // let v2d = layout.vertices();
 
-        for position in positions {
-            let lon = position.x().to_radians();
-            let lat = Self::lat_geodetic_to_authalic(
-                position.y().to_radians(),
-                &coef_fourier_geod_to_auth,
-            );
-            // Calculate 3d unit vectors for point P
-            let vector_3d = Vector3D::from_array(Self::to_3d(lat, lon));
+        // for position in positions {
+        //     let lon = position.x().to_radians();
+        //     let lat = Self::lat_geodetic_to_authalic(
+        //         position.y().to_radians(),
+        //         &coef_fourier_geod_to_auth,
+        //     );
+        //     // Calculate 3d unit vectors for point P
+        //     let vector_3d = Vector3D::from_array(Self::to_3d(lat, lon));
 
-            // starting from here, you need:
-            // - the 3d point that you want to project
-            // - the 3d vertexes of the icosahedron
-            // - the 2d vertexes of the layout
-            // Polyhedron faces
-            let faces_length = polyhedron.faces();
-            for index in 0..faces_length {
-                let face = usize::from(index);
-                let ids = triangles_ids[face];
+        //     // starting from here, you need:
+        //     // - the 3d point that you want to project
+        //     // - the 3d vertexes of the icosahedron
+        //     // - the 2d vertexes of the layout
+        //     // Polyhedron faces
+        //     let faces_length = polyhedron.faces();
+        //     for index in 0..faces_length {
+        //         let face = usize::from(index);
+        //         let ids = triangles_ids[face];
 
-                let triangle_3d = vec![
-                    ico_vectors[ids[0] as usize],
-                    ico_vectors[ids[1] as usize],
-                    ico_vectors[ids[2] as usize],
-                ];
-                if polyhedron.is_point_in_triangle(vector_3d, triangle_3d.clone()) {
-                    let (triangle_3d, triangle_2d) =
-                        polyhedron.triangles(layout, vector_3d, triangle_3d, v2d[face]);
-                    let ArcLengths { ab, bp, ap, .. } =
-                        polyhedron.triangle_arc_lengths(triangle_3d, vector_3d);
+        //         let triangle_3d = vec![
+        //             ico_vectors[ids[0] as usize],
+        //             ico_vectors[ids[1] as usize],
+        //             ico_vectors[ids[2] as usize],
+        //         ];
+        //         if polyhedron.is_point_in_triangle(vector_3d, triangle_3d.clone()) {
+        //             let (triangle_3d, triangle_2d) =
+        //                 polyhedron.triangles(layout, vector_3d, triangle_3d, v2d[face]);
+        //             let ArcLengths { ab, bp, ap, .. } =
+        //                 polyhedron.triangle_arc_lengths(triangle_3d, vector_3d);
 
-                    // angle ρ
-                    let rho: f64 =
-                        f64::acos(ap.cos() - ab.cos() * bp.cos()) / (ab.sin() * bp.sin());
+        //             // angle ρ
+        //             let rho: f64 =
+        //                 f64::acos(ap.cos() - ab.cos() * bp.cos()) / (ab.sin() * bp.sin());
 
-                    // 1. Calculate delta (δ)
-                    let delta = f64::acos(rho.sin() * ab.cos());
+        //             // 1. Calculate delta (δ)
+        //             let delta = f64::acos(rho.sin() * ab.cos());
 
-                    // 2. Calculate u
-                    let uv = (angle_beta + angle_gamma - rho - delta)
-                        / (angle_beta + angle_gamma - PI / 2.0);
+        //             // 2. Calculate u
+        //             let uv = (angle_beta + angle_gamma - rho - delta)
+        //                 / (angle_beta + angle_gamma - PI / 2.0);
 
-                    let cos_xp_y;
-                    if rho <= E.powi(-9) {
-                        cos_xp_y = ab.cos();
-                    } else {
-                        cos_xp_y = 1.0 / (rho.tan() * delta.tan())
-                    }
+        //             let cos_xp_y;
+        //             if rho <= E.powi(-9) {
+        //                 cos_xp_y = ab.cos();
+        //             } else {
+        //                 cos_xp_y = 1.0 / (rho.tan() * delta.tan())
+        //             }
 
-                    let xy = f64::sqrt((1.0 - bp.cos()) / (1.0 - cos_xp_y));
+        //             let xy = f64::sqrt((1.0 - bp.cos()) / (1.0 - cos_xp_y));
 
-                    // Triangle vertexes
-                    let (p0, p1, p2) = (&triangle_2d[0], &triangle_2d[1], &triangle_2d[2]);
+        //             // Triangle vertexes
+        //             let (p0, p1, p2) = (&triangle_2d[0], &triangle_2d[1], &triangle_2d[2]);
 
-                    // Between A e o C it gives point D
-                    let pd_x = p2.x + (p0.x - p2.x) * uv;
-                    let pd_y = p2.y + (p0.y - p2.y) * uv;
+        //             // Between A e o C it gives point D
+        //             let pd_x = p2.x + (p0.x - p2.x) * uv;
+        //             let pd_y = p2.y + (p0.y - p2.y) * uv;
 
-                    // Between D and B it gives point P
-                    let p_x = pd_x + (pd_x - p1.x) * xy;
-                    let p_y = pd_y + (pd_x - p1.y) * xy;
+        //             // Between D and B it gives point P
+        //             let p_x = pd_x + (pd_x - p1.x) * xy;
+        //             let p_y = pd_y + (pd_x - p1.y) * xy;
 
-                    out.push(Coord { x: p_x, y: p_y });
-                }
-            }
-        }
+        //             out.push(Coord { x: p_x, y: p_y });
+        //         }
+        //     }
+        // }
 
         out
     }

--- a/src/projections/projections/vgc.rs
+++ b/src/projections/projections/vgc.rs
@@ -39,7 +39,7 @@ impl Projection for Vgc {
         // Need the coeficcients to convert from geodetic to authalic
         let coef_fourier_geod_to_auth = Self::fourier_coefficients(KarneyCoefficients::GEODETIC_TO_AUTHALIC);
 
-        // // get 3d vertices of the icosahedron (unit vectors)
+        // get 3d vertices of the icosahedron (unit vectors)
         let ico_vectors = polyhedron.vertices();
         let triangles_ids = polyhedron.face_vertex_indices();
 
@@ -120,7 +120,7 @@ impl Projection for Vgc {
         //             out.push(Coord { x: p_x, y: p_y });
         //         }
         //     }
-        // }
+        }
 
         out
     }

--- a/src/projections/projections/vgc.rs
+++ b/src/projections/projections/vgc.rs
@@ -39,7 +39,7 @@ impl Projection for Vgc {
         // Need the coeficcients to convert from geodetic to authalic
         let coef_fourier_geod_to_auth = Self::fourier_coefficients(KarneyCoefficients::GEODETIC_TO_AUTHALIC);
 
-        // // get 3d vertices of the icosahedron
+        // // get 3d vertices of the icosahedron (unit vectors)
         let ico_vectors = polyhedron.vertices();
         let triangles_ids = polyhedron.face_vertex_indices();
 
@@ -52,20 +52,20 @@ impl Projection for Vgc {
 
         let v2d = layout.vertices();
 
-        // for position in positions {
-        //     let lon = position.x().to_radians();
-        //     let lat = Self::lat_geodetic_to_authalic(
-        //         position.y().to_radians(),
-        //         &coef_fourier_geod_to_auth,
-        //     );
-        //     // Calculate 3d unit vectors for point P
-        //     let vector_3d = Vector3D::from_array(Self::to_3d(lat, lon));
+        for position in positions {
+            let lon = position.x().to_radians();
+            let lat = Self::lat_geodetic_to_authalic(
+                position.y().to_radians(),
+                &coef_fourier_geod_to_auth,
+            );
+            // Calculate 3d unit vectors for point P
+            let vector_3d = Vector3D::from_array(Self::to_3d(lat, lon));
 
-        //     // starting from here, you need:
-        //     // - the 3d point that you want to project
-        //     // - the 3d vertexes of the icosahedron
-        //     // - the 2d vertexes of the layout
-        //     // Polyhedron faces
+            // starting from here, you need:
+            // - the 3d point that you want to project
+            // - the 3d vertexes of the icosahedron
+            // - the 2d vertexes of the layout
+            // Polyhedron faces
         //     let faces_length = polyhedron.faces();
         //     for index in 0..faces_length {
         //         let face = usize::from(index);
@@ -82,6 +82,7 @@ impl Projection for Vgc {
         //             let ArcLengths { ab, bp, ap, .. } =
         //                 polyhedron.triangle_arc_lengths(triangle_3d, vector_3d);
 
+        //             // ==== Slice and Dice formulas ====
         //             // angle ρ
         //             let rho: f64 =
         //                 f64::acos(ap.cos() - ab.cos() * bp.cos()) / (ab.sin() * bp.sin());
@@ -101,7 +102,9 @@ impl Projection for Vgc {
         //             }
 
         //             let xy = f64::sqrt((1.0 - bp.cos()) / (1.0 - cos_xp_y));
+        //             // =================================
 
+        //             // ==== Interpolation ====
         //             // Triangle vertexes
         //             let (p0, p1, p2) = (&triangle_2d[0], &triangle_2d[1], &triangle_2d[2]);
 
@@ -112,6 +115,7 @@ impl Projection for Vgc {
         //             // Between D and B it gives point P
         //             let p_x = pd_x + (pd_x - p1.x) * xy;
         //             let p_y = pd_y + (pd_x - p1.y) * xy;
+        //             // ======================
 
         //             out.push(Coord { x: p_x, y: p_y });
         //         }


### PR DESCRIPTION
[Issue 35](https://github.com/GeoPlegma/GeoPlegma/issues/35)

- Added new polyhedra constants file
- New methods for `vector3D`
- Auto-formatted the code
- Added and changed new methods to the icosahedron
- New `enum` for polygon faces
- Temporary comment of the projection.
- Also removing the `triangles` function. It's something specific to the slice and and dice where it splits the spherical triangle into sub-triangle and finds the sub-triangle that contains the input lat/lon.

Need to merge this as soon as we can. We can take care of the 2D net later. I would prefer that Michael handles the workspaces PR first after we merge this.