### PR TITLE
Refactored BBox replacing Option<Vec<Vec>> with geo::Rect<f64>

### DIFF
--- a/dggrs/src/adapters/dggal/common.rs
+++ b/dggrs/src/adapters/dggal/common.rs
@@ -10,10 +10,7 @@
 use crate::error::dggal::DggalError;
 use crate::models::common::{Zone, ZoneID, Zones};
 use dggal_rust::dggal::{DGGRS, DGGRSZone, GeoExtent, GeoPoint};
-use geo::LineString;
-use geo::Point;
-use geo::Polygon;
-use geo::coord;
+use geo::{LineString, Point, Polygon, Rect, coord};
 
 pub fn ids_to_zones(dggrs: DGGRS, ids: Vec<DGGRSZone>) -> Result<Zones, DggalError> {
     let zones: Vec<Zone> = ids
@@ -100,19 +97,19 @@ pub fn to_geo_point(pt: Point) -> GeoPoint {
     }
 }
 
-pub fn to_geo_extent(bbox: Option<Vec<Vec<f64>>>) -> GeoExtent {
-    match bbox {
-        Some(coords) if coords.len() == 2 && coords[0].len() == 2 && coords[1].len() == 2 => {
-            let ll = GeoPoint {
-                lat: coords[0][1].to_radians(),
-                lon: coords[0][0].to_radians(),
-            };
-            let ur = GeoPoint {
-                lat: coords[1][1].to_radians(),
-                lon: coords[1][0].to_radians(),
-            };
-            GeoExtent { ll, ur }
-        }
-        _ => panic!("Invalid bounding box format"), // FIX: remove panic. bbox: Option<Vec<Vec<f64>>> has to be replaced with geo::geometry::Rect here https://docs.rs/geo/latest/geo/geometry/struct.Rect.html
+/// Convert geo::Rect BBox to DGGAL::GeoExtent
+pub fn bbox_to_geoextent(bbox: &Rect<f64>) -> GeoExtent {
+    let min = bbox.min(); // lower-left in degrees
+    let max = bbox.max(); // upper-right in degrees
+
+    GeoExtent {
+        ll: GeoPoint {
+            lat: min.y.to_radians(),
+            lon: min.x.to_radians(),
+        },
+        ur: GeoPoint {
+            lat: max.y.to_radians(),
+            lon: max.x.to_radians(),
+        },
     }
 }

--- a/dggrs/src/adapters/dggal/grids.rs
+++ b/dggrs/src/adapters/dggal/grids.rs
@@ -52,7 +52,7 @@ impl DggrsPort for DggalImpl {
         &self,
         depth: u8,
         densify: bool,
-        bbox: Option<Rect>,
+        bbox: Option<Rect<f64>>,
     ) -> Result<Zones, PortError> {
         let dggrs = get_dggrs(&self.grid_name)?;
 

--- a/dggrs/src/adapters/dggrid/common.rs
+++ b/dggrs/src/adapters/dggrid/common.rs
@@ -10,7 +10,7 @@
 use crate::error::dggrid::DggridError;
 use crate::models::common::{Zone, ZoneID, Zones};
 use core::f64;
-use geo::geometry::{LineString, Point, Polygon};
+use geo::{LineString, Point, Polygon, Rect};
 use rand::distributions::{Alphanumeric, DistString};
 use std::fs;
 use std::fs::File;
@@ -276,16 +276,12 @@ where
     Ok(io::BufReader::new(file).lines())
 }
 
-pub fn bbox_to_aigen(bbox: &Vec<Vec<f64>>, bboxfile: &PathBuf) -> io::Result<()> {
-    if bbox.len() != 2 || bbox[0].len() != 2 || bbox[1].len() != 2 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Invalid bounding box format",
-        ));
-    }
+pub fn bbox_to_aigen(bbox: &Rect<f64>, bboxfile: &PathBuf) -> io::Result<()> {
+    let min = bbox.min();
+    let max = bbox.max();
 
-    let (minx, miny) = (bbox[0][0], bbox[0][1]);
-    let (maxx, maxy) = (bbox[1][0], bbox[1][1]);
+    let (minx, miny) = (min.x, min.y);
+    let (maxx, maxy) = (max.x, max.y);
 
     // define the 5 vertices (closing the polygon)
     let vertices = vec![

--- a/dggrs/src/adapters/dggrid/igeo7.rs
+++ b/dggrs/src/adapters/dggrid/igeo7.rs
@@ -20,6 +20,7 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use tracing::debug;
 pub const CLIP_CELL_DENSIFICATION: u8 = 50; // DGGRID option
+use geo::Rect;
 
 pub struct Igeo7Impl {
     pub adapter: DggridAdapter,
@@ -47,7 +48,7 @@ impl DggrsPort for Igeo7Impl {
         &self,
         depth: u8,
         densify: bool,
-        bbox: Option<Vec<Vec<f64>>>,
+        bbox: Option<Rect<f64>>,
     ) -> Result<Zones, PortError> {
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
             common::dggrid_setup(&self.adapter.workdir);

--- a/dggrs/src/adapters/dggrid/isea3h.rs
+++ b/dggrs/src/adapters/dggrid/isea3h.rs
@@ -13,7 +13,7 @@ use crate::error::port::PortError;
 use crate::models::common::Zones;
 use crate::ports::dggrs::DggrsPort;
 use core::f64;
-use geo::geometry::Point;
+use geo::{Point, Rect};
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::{self, Write};
@@ -47,7 +47,7 @@ impl DggrsPort for Isea3hImpl {
         &self,
         depth: u8,
         densify: bool,
-        bbox: Option<Vec<Vec<f64>>>,
+        bbox: Option<Rect<f64>>,
     ) -> Result<Zones, PortError> {
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
             common::dggrid_setup(&self.adapter.workdir);

--- a/dggrs/src/adapters/h3o/common.rs
+++ b/dggrs/src/adapters/h3o/common.rs
@@ -14,6 +14,7 @@ use crate::{
 use geo::{Coord, CoordsIter, LineString, Point, Polygon};
 use h3o::{Boundary, CellIndex, LatLng, Resolution};
 
+/// Translates integer resolution to H3 string resolution
 pub fn res(level: u8) -> Resolution {
     Resolution::try_from(level).unwrap_or_else(|_| panic!("Invalid H3 resolution: {}", level))
 }

--- a/dggrs/src/adapters/h3o/h3.rs
+++ b/dggrs/src/adapters/h3o/h3.rs
@@ -45,7 +45,7 @@ impl DggrsPort for H3Impl {
         &self,
         depth: u8,
         _densify: bool,
-        bbox: Option<Rect>,
+        bbox: Option<Rect<f64>>,
     ) -> Result<Zones, PortError> {
         let cells: Vec<CellIndex>;
 

--- a/dggrs/src/constants.rs
+++ b/dggrs/src/constants.rs
@@ -1,0 +1,11 @@
+use geo::{Coord, Rect};
+
+pub fn whole_earth_bbox() -> Rect<f64> {
+    Rect::new(
+        Coord {
+            x: -180.0,
+            y: -90.0,
+        },
+        Coord { x: 180.0, y: 90.0 },
+    )
+}

--- a/dggrs/src/lib.rs
+++ b/dggrs/src/lib.rs
@@ -9,6 +9,7 @@
 
 #![doc = include_str!("../../README.md")]
 pub mod adapters;
+pub mod constants;
 pub mod dggrs;
 pub mod error;
 pub mod factory;

--- a/dggrs/src/ports/dggrs.rs
+++ b/dggrs/src/ports/dggrs.rs
@@ -10,13 +10,15 @@
 use crate::error::port::PortError;
 use crate::models::common::Zones;
 use geo::Point;
-// That is the port
+use geo::Rect;
+
+/// The DGGRS port trait. Each adapter can only implment the functions defined here.
 pub trait DggrsPort: Send + Sync {
     fn zones_from_bbox(
         &self,
         depth: u8,
         densify: bool,
-        bbox: Option<Vec<Vec<f64>>>,
+        bbox: Option<Rect<f64>>,
     ) -> Result<Zones, PortError>;
 
     fn zone_from_point(&self, depth: u8, point: Point, densify: bool) -> Result<Zones, PortError>; // NOTE:Consider accepting a vector of Points.


### PR DESCRIPTION
Small change to replace our own parameter type `Option<Vec<Vec>>` with geo's `Rect`