### PR TITLE
Adding boolean switches to genereate `children`, `neighbors`, `area`, `vertrex_count`, `geometry` and `geometry_densification`

### DIFF
--- a/dggrs/Cargo.toml
+++ b/dggrs/Cargo.toml
@@ -1,3 +1,12 @@
+# Copyright 2025 contributors to the GeoPlegmata project.
+# Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+#
+# Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
+# discretion. This file may not be copied, modified, or distributed
+# except according to those terms.
+
 [package]
 name = "dggrs"
 version = "0.2.0"

--- a/dggrs/src/adapters/dggal/common.rs
+++ b/dggrs/src/adapters/dggal/common.rs
@@ -9,60 +9,87 @@
 
 use crate::error::dggal::DggalError;
 use crate::models::common::{Zone, ZoneId, Zones};
+use crate::ports::dggrs::DggrsPortConfig;
 use dggal_rust::dggal::{DGGRS, DGGRSZone, GeoExtent, GeoPoint};
-use geo::{LineString, Point, Polygon, Rect, coord};
+use geo::{GeodesicArea, LineString, Point, Polygon, Rect, coord};
 
-pub fn ids_to_zones(dggrs: DGGRS, ids: Vec<DGGRSZone>) -> Result<Zones, DggalError> {
-    let zones: Vec<Zone> = ids
+pub fn to_zones(
+    dggrs: DGGRS,
+    dggal_zones: Vec<DGGRSZone>,
+    conf: DggrsPortConfig,
+) -> Result<Zones, DggalError> {
+    let zones: Vec<Zone> = dggal_zones
         .into_iter()
-        .map(|id| {
-            //let dggal_geo_points: Vec<GeoPoint> = dggrs.getZoneWGS84Vertices(id);
-            let dggal_geo_points: Vec<GeoPoint> = dggrs.getZoneRefinedWGS84Vertices(id, 0);
-            let region: Polygon<f64> = to_polygon(&dggal_geo_points);
+        .map(|dggal_zone| {
+            let id = ZoneId::new_int(dggal_zone);
 
-            let center_point = dggrs.getZoneWGS84Centroid(id);
-            let center: Point<f64> = to_point(&center_point);
+            let center = if conf.center {
+                let center_point = dggrs.getZoneWGS84Centroid(dggal_zone);
+                Some(to_point(&center_point))
+            } else {
+                None
+            };
 
-            let count_edges: u32 = dggrs.countZoneEdges(id).try_into().unwrap(); // NOTE: Implement proper error ahndling in error.rs (to be created) and do pattern matching here. 
-            //
-            //
-            let count_edges: u32 = dggrs.countZoneEdges(id).try_into().map_err(|e| {
-                DggalError::EdgeCountConversion {
-                    zone_id: id.to_string(),
-                    source: e,
-                }
-            })?;
+            let region = if conf.neighbors || conf.area_sqm {
+                let dggal_geo_points = if conf.densify {
+                    dggrs.getZoneRefinedWGS84Vertices(dggal_zone, 0)
+                } else {
+                    dggrs.getZoneWGS84Vertices(dggal_zone)
+                };
+                Some(to_polygon(&dggal_geo_points))
+            } else {
+                None
+            };
 
-            // TODO: Wrap the children and neighbors into an if statement if requested.
-            //let children = dggrs.getSubZones(id, 1);
+            let area_sqm = if conf.area_sqm {
+                region.as_ref().map(|r| r.geodesic_area_unsigned()) // NOTE: It is also an option to use the build in area function of H3o
+            } else {
+                None
+            };
 
-            let children: Option<Vec<ZoneId>> = Some(
-                dggrs
-                    .getZoneChildren(id)
+            let vertex_count = if conf.vertex_count {
+                let vc = dggrs.countZoneEdges(dggal_zone).try_into().map_err(|e| {
+                    DggalError::EdgeCountConversion {
+                        zone_id: dggal_zone.to_string(),
+                        source: e,
+                    }
+                })?;
+                Some(vc)
+            } else {
+                None
+            };
+
+            let children = if conf.children {
+                let c: Vec<ZoneId> = dggrs
+                    .getZoneChildren(dggal_zone)
                     .into_iter()
                     .map(to_u64_zone_id)
-                    .collect(),
-            );
+                    .collect();
+                Some(c)
+            } else {
+                None
+            };
 
-            let mut nb_types: [i32; 6] = [0; 6];
-            //let neighbors = dggrs.getZoneNeighbors(id, &mut nb_types);
-
-            let neighbors: Option<Vec<ZoneId>> = Some(
-                dggrs
-                    .getZoneNeighbors(id, &mut nb_types)
+            let neighbors = if conf.neighbors {
+                let mut nb_types: [i32; 6] = [0; 6]; // WARN: don't replace this
+                let n: Vec<ZoneId> = dggrs
+                    .getZoneNeighbors(dggal_zone, &mut nb_types)
                     .into_iter()
                     .map(to_u64_zone_id)
-                    .collect(),
-            );
+                    .collect();
+                Some(n)
+            } else {
+                None
+            };
 
             Ok(Zone {
-                id: ZoneId::IntId(id),
-                region: Some(region),
-                center: Some(center),
-                vertex_count: Some(count_edges),
-                children: Some(children),
-                neighbors: Some(neighbors),
-                area_sqm: Some(area_sqm),
+                id,
+                region,
+                center,
+                vertex_count,
+                children,
+                neighbors,
+                area_sqm,
             })
         })
         .collect::<Result<Vec<Zone>, DggalError>>()?;

--- a/dggrs/src/adapters/dggal/common.rs
+++ b/dggrs/src/adapters/dggal/common.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/dggal/common.rs
+++ b/dggrs/src/adapters/dggal/common.rs
@@ -57,11 +57,12 @@ pub fn ids_to_zones(dggrs: DGGRS, ids: Vec<DGGRSZone>) -> Result<Zones, DggalErr
 
             Ok(Zone {
                 id: ZoneId::IntId(id),
-                region,
-                vertex_count: count_edges,
-                center,
-                children, // TODO: we need to make an enum for string and integer based indicies
-                neighbors,
+                region: Some(region),
+                center: Some(center),
+                vertex_count: Some(count_edges),
+                children: Some(children),
+                neighbors: Some(neighbors),
+                area_sqm: Some(area_sqm),
             })
         })
         .collect::<Result<Vec<Zone>, DggalError>>()?;

--- a/dggrs/src/adapters/dggal/context.rs
+++ b/dggrs/src/adapters/dggal/context.rs
@@ -1,3 +1,12 @@
+// Copyright 2025 contributors to the GeoPlegmata project.
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
+//
+// Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
+// discretion. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use once_cell::sync::Lazy;
 use std::env;
 use std::sync::Mutex;

--- a/dggrs/src/adapters/dggal/dggal.rs
+++ b/dggrs/src/adapters/dggal/dggal.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/dggal/grids.rs
+++ b/dggrs/src/adapters/dggal/grids.rs
@@ -131,7 +131,7 @@ impl DggrsPort for DggalImpl {
         let dggrs = get_dggrs(&self.grid_name)?;
         let zones = vec![zone_u64];
 
-        Ok(to_zones(dggrs, zones)?)
+        Ok(to_zones(dggrs, zones, cfg)?)
     }
 
     fn min_refinement_level(&self) -> Result<RefinementLevel, GeoPlegmaError> {

--- a/dggrs/src/adapters/dggal/grids.rs
+++ b/dggrs/src/adapters/dggal/grids.rs
@@ -7,7 +7,7 @@
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::adapters::dggal::common::{bbox_to_geoextent, ids_to_zones, to_geo_point};
+use crate::adapters::dggal::common::{bbox_to_geoextent, to_geo_point, to_zones};
 use crate::adapters::dggal::context::GLOBAL_DGGAL;
 use crate::constants::whole_earth_bbox;
 use crate::error::dggal::DggalError;
@@ -62,7 +62,7 @@ impl DggrsPort for DggalImpl {
         let dggrs = get_dggrs(&self.grid_name)?;
 
         let zones = dggrs.listZones(i32::from(refinement_level), &geo_extent);
-        Ok(ids_to_zones(dggrs, zones)?)
+        Ok(to_zones(dggrs, zones, cfg)?)
     }
     fn zone_from_point(
         &self,
@@ -74,7 +74,7 @@ impl DggrsPort for DggalImpl {
         let dggrs = get_dggrs(&self.grid_name)?;
         let zone = dggrs.getZoneFromWGS84Centroid(refinement_level.get(), &to_geo_point(point));
         let zones = vec![zone];
-        Ok(ids_to_zones(dggrs, zones)?)
+        Ok(to_zones(dggrs, zones, cfg)?)
     }
     fn zones_from_parent(
         &self,
@@ -114,7 +114,7 @@ impl DggrsPort for DggalImpl {
 
         let zones = dggrs.getSubZones(parent_u64, i32::from(relative_depth));
 
-        Ok(ids_to_zones(dggrs, zones)?)
+        Ok(to_zones(dggrs, zones, cfg)?)
     }
     fn zone_from_id(
         &self,
@@ -131,7 +131,7 @@ impl DggrsPort for DggalImpl {
         let dggrs = get_dggrs(&self.grid_name)?;
         let zones = vec![zone_u64];
 
-        Ok(ids_to_zones(dggrs, zones)?)
+        Ok(to_zones(dggrs, zones)?)
     }
 
     fn min_refinement_level(&self) -> Result<RefinementLevel, GeoPlegmaError> {

--- a/dggrs/src/adapters/dggal/grids.rs
+++ b/dggrs/src/adapters/dggal/grids.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/dggal/mod.rs
+++ b/dggrs/src/adapters/dggal/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/dggrid/common.rs
+++ b/dggrs/src/adapters/dggrid/common.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 iontributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/dggrid/common.rs
+++ b/dggrs/src/adapters/dggrid/common.rs
@@ -7,169 +7,303 @@
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::error::dggrid::DggridError;
-use crate::error::port::GeoPlegmaError;
-use crate::models::common::{RefinementLevel, Zone, ZoneId, Zones};
-use core::f64;
-use geo::{LineString, Point, Polygon, Rect};
-use rand::distributions::{Alphanumeric, DistString};
-use std::fs;
-use std::fs::File;
-use std::io::{self, BufRead, Write};
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use tracing::debug;
+pub mod dggrid {
+    use rand::distributions::{Alphanumeric, DistString};
+    use std::fs;
+    use std::path::PathBuf;
+    use std::process::Command;
 
-pub const DENSIFICATION: u8 = 50; // DGGRID option
-
-#[derive(Debug)]
-pub struct IdArray {
-    pub id: Option<String>,
-    pub arr: Option<Vec<String>>,
+    pub fn setup(workdir: &PathBuf) -> (PathBuf, PathBuf, PathBuf, PathBuf, PathBuf, PathBuf) {
+        let code = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
+        let meta_path = workdir.join(&code).with_extension("meta"); // metafile
+        let aigen_path = workdir.join(&code).with_extension("gen"); // AIGEN
+        let children_path = workdir.join(&code).with_extension("chd"); // Children
+        let neighbor_path = workdir.join(&code).with_extension("nbr"); // Neightbors
+        let bbox_path = workdir.join(&code).with_extension("bbox"); // BBox
+        let input_path = workdir.join(&code).with_extension("txt"); // Input file for e.g. points
+        (
+            meta_path,
+            aigen_path,
+            children_path,
+            neighbor_path,
+            bbox_path,
+            input_path,
+        )
+    }
+    pub fn execute(dggrid_path: &PathBuf, meta_path: &PathBuf) {
+        let _ = Command::new(&dggrid_path).arg(&meta_path).output(); // FIX: Better handling of output and raise DggridError::DggridExecutionFailed
+    }
 }
 
-pub fn dggrid_setup(workdir: &PathBuf) -> (PathBuf, PathBuf, PathBuf, PathBuf, PathBuf, PathBuf) {
-    let code = Alphanumeric.sample_string(&mut rand::thread_rng(), 16);
-    let meta_path = workdir.join(&code).with_extension("meta"); // metafile
-    let aigen_path = workdir.join(&code).with_extension("gen"); // AIGEN
-    let children_path = workdir.join(&code).with_extension("chd"); // Children
-    let neighbor_path = workdir.join(&code).with_extension("nbr"); // Neightbors
-    let bbox_path = workdir.join(&code).with_extension("bbox"); // BBox
-    let input_path = workdir.join(&code).with_extension("txt"); // Input file for e.g. points
-    (
-        meta_path,
-        aigen_path,
-        children_path,
-        neighbor_path,
-        bbox_path,
-        input_path,
-    )
-}
+pub mod write {
+    use crate::models::common::RefinementLevel;
+    use geo::Rect;
+    use std::fs;
+    use std::io::{self, Write};
+    use std::path::PathBuf;
+    use tracing::debug;
 
-pub fn dggrid_metafile(
-    metafile: &PathBuf,
-    refinement_level: &RefinementLevel,
-    cell_output_file_name: &PathBuf,
-    children_output_file_name: &PathBuf,
-    neighbor_output_file_name: &PathBuf,
-    densify: bool,
-) -> io::Result<()> {
-    debug!("Writing to {:?}", metafile);
-    let mut file = fs::File::create(metafile)?;
-    writeln!(file, "longitude_wrap_mode UNWRAP_EAST")?;
-    writeln!(file, "cell_output_type AIGEN")?;
-    writeln!(file, "unwrap_points FALSE")?;
-    writeln!(file, "output_cell_label_type OUTPUT_ADDRESS_TYPE")?;
-    writeln!(file, "precision 7")?;
-    writeln!(file, "dggs_res_spec {}", refinement_level.get())?;
-    writeln!(file, "z3_invalid_digit 3")?;
+    pub const DENSIFICATION: u8 = 50; // DGGRID option
 
-    writeln!(
-        file,
-        "cell_output_file_name {}",
-        cell_output_file_name.to_string_lossy().into_owned()
-    )?;
+    pub fn metafile(
+        metafile: &PathBuf,
+        refinement_level: &RefinementLevel,
+        cell_output_file_name: &PathBuf,
+        children_output_file_name: &PathBuf,
+        neighbor_output_file_name: &PathBuf,
+        densify: bool,
+    ) -> io::Result<()> {
+        debug!("Writing to {:?}", metafile);
+        let mut file = fs::File::create(metafile)?;
+        writeln!(file, "longitude_wrap_mode UNWRAP_EAST")?;
+        writeln!(file, "cell_output_type AIGEN")?;
+        writeln!(file, "unwrap_points FALSE")?;
+        writeln!(file, "output_cell_label_type OUTPUT_ADDRESS_TYPE")?;
+        writeln!(file, "precision 7")?;
+        writeln!(file, "dggs_res_spec {}", refinement_level.get())?;
+        writeln!(file, "z3_invalid_digit 3")?;
 
-    writeln!(file, "neighbor_output_type TEXT")?;
-    writeln!(
-        file,
-        "neighbor_output_file_name {}",
-        neighbor_output_file_name.to_string_lossy().into_owned()
-    )?;
-    writeln!(file, "children_output_type TEXT")?;
-    writeln!(
-        file,
-        "children_output_file_name {}",
-        children_output_file_name.to_string_lossy().into_owned()
-    )?;
+        writeln!(
+            file,
+            "cell_output_file_name {}",
+            cell_output_file_name.to_string_lossy().into_owned()
+        )?;
 
-    if densify == true {
-        writeln!(file, "densification {}", DENSIFICATION)?;
+        writeln!(file, "neighbor_output_type TEXT")?;
+        writeln!(
+            file,
+            "neighbor_output_file_name {}",
+            neighbor_output_file_name.to_string_lossy().into_owned()
+        )?;
+        writeln!(file, "children_output_type TEXT")?;
+        writeln!(
+            file,
+            "children_output_file_name {}",
+            children_output_file_name.to_string_lossy().into_owned()
+        )?;
+
+        if densify == true {
+            writeln!(file, "densification {}", DENSIFICATION)?;
+        }
+
+        Ok(())
     }
 
-    Ok(())
-}
-pub fn dggrid_execute(dggrid_path: &PathBuf, meta_path: &PathBuf) {
-    let _ = Command::new(&dggrid_path).arg(&meta_path).output(); // FIX: Better handling of output and raise DggridError::DggridExecutionFailed
-}
+    pub fn bbox(bbox: &Rect<f64>, bboxfile: &PathBuf) -> io::Result<()> {
+        let min = bbox.min();
+        let max = bbox.max();
 
-pub fn dggrid_parse(
-    aigen_path: &PathBuf,
-    children_path: &PathBuf,
-    neighbor_path: &PathBuf,
-) -> Result<Zones, GeoPlegmaError> {
-    let aigen_data = read_file(&aigen_path)?;
-    let mut result = parse_aigen(&aigen_data)?;
-    let children_data = read_file(&children_path)?;
-    let children = parse_children(&children_data)?;
-    assign_field(&mut result, children, "children");
+        let (minx, miny) = (min.x, min.y);
+        let (maxx, maxy) = (max.x, max.y);
 
-    let neighbor_data = read_file(&neighbor_path)?;
-    let neighbors = parse_neighbors(&neighbor_data)?;
-    assign_field(&mut result, neighbors, "neighbors");
-    Ok(result)
-}
+        // define the 5 vertices (closing the polygon)
+        let vertices = vec![
+            (minx, miny), // lower-left
+            (maxx, miny), // lower-right
+            (maxx, maxy), // upper-right
+            (minx, maxy), // upper-left
+            (minx, miny), // close
+        ];
+        let mut file = fs::File::create(bboxfile)?;
 
-pub fn parse_aigen(data: &String) -> Result<Zones, GeoPlegmaError> {
-    let mut zone_id = ZoneId::new_str(&"0")?;
-    let mut zones = Zones { zones: Vec::new() };
+        // First line: ID and center of the bbox (NOT part of the ring)
+        let center_x = (minx + maxx) / 2.0;
+        let center_y = (miny + maxy) / 2.0;
+        writeln!(file, "1 {:.7} {:.7}", center_x, center_y)?;
 
-    let mut raw_coords: Vec<(f64, f64)> = vec![];
-    let mut ply: Polygon;
-    let mut pnt = Point::new(0.0, 0.0);
-    let mut v_count = 0u32;
+        for (x, y) in &vertices {
+            writeln!(file, "{:.7} {:.7}", x, y)?;
+        }
 
-    // loop over the entire AIGEN file
-    for line in data.lines() {
-        // println!("{:?}", line);
-        let line_parts: Vec<&str> = line.split_whitespace().collect();
-        // The first line of each hexagon is always 3 strings, the first is the ID and the
-        // second two are the center point
+        writeln!(file, "END")?;
+        writeln!(file, "END")?;
 
-        if line_parts.len() == 3 {
-            zone_id = ZoneId::new_hex(&line_parts[0])?;
-            pnt = Point::new(
-                line_parts[1]
-                    .parse::<f64>()
-                    .expect("cannot parse floating point number"),
-                line_parts[2]
-                    .parse::<f64>()
-                    .expect("cannot parse floating point number"),
-            );
-        // these are coordinate pairs for the region
-        } else if line_parts.len() == 2 {
-            v_count += 1;
-            raw_coords.push((
-                line_parts[0]
-                    .parse::<f64>()
-                    .expect("cannot parse floating point number"),
-                line_parts[1]
-                    .parse::<f64>()
-                    .expect("cannot parse floating point number"),
-            ))
-        // if it just 1 part AND it is END AND if the vertex count is larger than 1
-        } else if line_parts.len() == 1 && line_parts[0] == "END" && v_count > 1 {
-            ply = Polygon::new(LineString::from(raw_coords.clone()), vec![]);
+        Ok(())
+    }
 
-            let zone = Zone {
-                id: zone_id.clone(),
-                region: Some(ply),
-                center: Some(pnt),
-                vertex_count: Some(v_count - 1),
-                children: Some(children),
-                neighbors: Some(neighbors),
-                area_sqm: Some(area_sqm),
-            };
-            zones.zones.push(zone);
-
-            // reset
-            raw_coords.clear();
-            v_count = 0;
+    pub fn file(file: PathBuf) {
+        if let Ok(lines) = super::read::lines(file) {
+            // Consumes the iterator, returns an (Optional) String
+            for line in lines.flatten() {
+                debug!("{}", line);
+            }
         }
     }
-    Ok(zones)
 }
-pub fn dggrid_cleanup(
+pub mod read {
+    use crate::error::dggrid::DggridError;
+    use crate::error::port::GeoPlegmaError;
+    use crate::models::common::{Zone, ZoneId, Zones};
+    use core::f64;
+    use geo::{LineString, Point, Polygon};
+    use std::fs;
+    use std::fs::File;
+    use std::io::{self, BufRead};
+    use std::path::{Path, PathBuf};
+
+    #[derive(Debug)]
+    pub struct IdArray {
+        pub id: Option<String>,
+        pub arr: Option<Vec<String>>,
+    }
+
+    pub fn dggrid_parse(
+        aigen_path: &PathBuf,
+        children_path: &PathBuf,
+        neighbor_path: &PathBuf,
+    ) -> Result<Zones, GeoPlegmaError> {
+        let aigen_data = file(&aigen_path)?;
+        let mut result = aigen(&aigen_data)?;
+        let children_data = file(&children_path)?;
+        let children = children(&children_data)?;
+        assign_field(&mut result, children, "children");
+
+        let neighbor_data = file(&neighbor_path)?;
+        let neighbors = neighbors(&neighbor_data)?;
+        assign_field(&mut result, neighbors, "neighbors");
+        Ok(result)
+    }
+
+    pub fn aigen(data: &String) -> Result<Zones, GeoPlegmaError> {
+        let mut zone_id = ZoneId::new_str(&"0")?; // FIX: Use ZoneId::new_hex
+        let mut zones = Zones { zones: Vec::new() };
+
+        let mut raw_coords: Vec<(f64, f64)> = vec![];
+        let mut region: Polygon;
+        let mut center = Point::new(0.0, 0.0);
+        let mut v_count = 0u32;
+
+        // loop over the entire AIGEN file
+        for line in data.lines() {
+            // println!("{:?}", line);
+            let line_parts: Vec<&str> = line.split_whitespace().collect();
+            // The first line of each hexagon is always 3 strings, the first is the ID and the
+            // second two are the center point
+
+            if line_parts.len() == 3 {
+                zone_id = ZoneId::new_hex(&line_parts[0])?;
+                center = Point::new(
+                    line_parts[1]
+                        .parse::<f64>()
+                        .expect("cannot parse floating point number"),
+                    line_parts[2]
+                        .parse::<f64>()
+                        .expect("cannot parse floating point number"),
+                );
+            // these are coordinate pairs for the region
+            } else if line_parts.len() == 2 {
+                v_count += 1;
+                raw_coords.push((
+                    line_parts[0]
+                        .parse::<f64>()
+                        .expect("cannot parse floating point number"),
+                    line_parts[1]
+                        .parse::<f64>()
+                        .expect("cannot parse floating point number"),
+                ))
+            // if it just 1 part AND it is END AND if the vertex count is larger than 1
+            } else if line_parts.len() == 1 && line_parts[0] == "END" && v_count > 1 {
+                region = Polygon::new(LineString::from(raw_coords.clone()), vec![]);
+
+                let zone = Zone {
+                    id: zone_id.clone(),
+                    region: Some(region),
+                    center: Some(center),
+                    vertex_count: Some(v_count - 1),
+                    children: Some(children),
+                    neighbors: Some(neighbors),
+                    area_sqm: Some(area_sqm),
+                };
+                zones.zones.push(zone);
+
+                // reset
+                raw_coords.clear();
+                v_count = 0;
+            }
+        }
+        Ok(zones)
+    }
+
+    pub fn children(data: &String) -> Result<Vec<IdArray>, DggridError> {
+        Ok(data
+            .lines()
+            .filter_map(|line| {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.is_empty() {
+                    return None;
+                }
+
+                let id = Some(format!("{}", parts[0]));
+                let arr = parts.iter().skip(1).map(|s| format!("{}", s)).collect();
+
+                Some(IdArray { id, arr: Some(arr) })
+            })
+            .collect())
+    }
+
+    pub fn neighbors(data: &String) -> Result<Vec<IdArray>, DggridError> {
+        Ok(data
+            .lines()
+            .filter_map(|line| {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.is_empty() {
+                    return None;
+                }
+
+                let id = Some(format!("{}", parts[0]));
+                let arr = parts.iter().skip(1).map(|s| format!("{}", s)).collect();
+
+                Some(IdArray { id, arr: Some(arr) })
+            })
+            .collect())
+    }
+
+    pub fn assign_field(zones: &mut Zones, data: Vec<IdArray>, field: &str) {
+        for item in data {
+            if let Some(ref id_str) = item.id {
+                let target_id = ZoneId::StrId(id_str.clone());
+                if let Some(cell) = zones.zones.iter_mut().find(|c| c.id == target_id) {
+                    match field {
+                        "children" => {
+                            cell.children = item
+                                .arr
+                                .clone()
+                                .map(|v| v.into_iter().map(ZoneId::StrId).collect())
+                        }
+                        "neighbors" => {
+                            cell.neighbors = item
+                                .arr
+                                .clone()
+                                .map(|v| v.into_iter().map(ZoneId::StrId).collect())
+                        }
+                        _ => panic!("Unknown field: {}", field),
+                    }
+                }
+            }
+        }
+    }
+    // Read aigen file produced by DGGRID
+    // Todo: this is inefficient, use the read_lines function as in print_file
+    // https://doc.rust-lang.org/rust-by-example/std_misc/file/read_lines.html
+    pub fn file(path: &Path) -> Result<String, DggridError> {
+        Ok(fs::read_to_string(path).map_err(|e| DggridError::FileRead {
+            path: path.display().to_string(),
+            source: e,
+        })?)
+    }
+
+    pub fn lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+    where
+        P: AsRef<Path>,
+    {
+        let file = File::open(filename)?;
+        Ok(io::BufReader::new(file).lines())
+    }
+}
+
+use std::fs;
+use std::path::PathBuf;
+pub fn cleanup(
     meta_path: &PathBuf,
     aigen_path: &PathBuf,
     children_path: &PathBuf,
@@ -181,122 +315,4 @@ pub fn dggrid_cleanup(
     let _ = fs::remove_file(children_path);
     let _ = fs::remove_file(neighbor_path);
     let _ = fs::remove_file(bbox_path);
-}
-
-pub fn parse_children(data: &String) -> Result<Vec<IdArray>, DggridError> {
-    Ok(data
-        .lines()
-        .filter_map(|line| {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.is_empty() {
-                return None;
-            }
-
-            let id = Some(format!("{}", parts[0]));
-            let arr = parts.iter().skip(1).map(|s| format!("{}", s)).collect();
-
-            Some(IdArray { id, arr: Some(arr) })
-        })
-        .collect())
-}
-
-pub fn parse_neighbors(data: &String) -> Result<Vec<IdArray>, DggridError> {
-    Ok(data
-        .lines()
-        .filter_map(|line| {
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.is_empty() {
-                return None;
-            }
-
-            let id = Some(format!("{}", parts[0]));
-            let arr = parts.iter().skip(1).map(|s| format!("{}", s)).collect();
-
-            Some(IdArray { id, arr: Some(arr) })
-        })
-        .collect())
-}
-
-pub fn assign_field(zones: &mut Zones, data: Vec<IdArray>, field: &str) {
-    for item in data {
-        if let Some(ref id_str) = item.id {
-            let target_id = ZoneId::StrId(id_str.clone());
-            if let Some(cell) = zones.zones.iter_mut().find(|c| c.id == target_id) {
-                match field {
-                    "children" => {
-                        cell.children = item
-                            .arr
-                            .clone()
-                            .map(|v| v.into_iter().map(ZoneId::StrId).collect())
-                    }
-                    "neighbors" => {
-                        cell.neighbors = item
-                            .arr
-                            .clone()
-                            .map(|v| v.into_iter().map(ZoneId::StrId).collect())
-                    }
-                    _ => panic!("Unknown field: {}", field),
-                }
-            }
-        }
-    }
-}
-
-pub fn print_file(file: PathBuf) {
-    if let Ok(lines) = read_lines(file) {
-        // Consumes the iterator, returns an (Optional) String
-        for line in lines.flatten() {
-            debug!("{}", line);
-        }
-    }
-}
-
-// Read aigen file produced by DGGRID
-// Todo: this is inefficient, use the read_lines function as in print_file
-// https://doc.rust-lang.org/rust-by-example/std_misc/file/read_lines.html
-pub fn read_file(path: &Path) -> Result<String, DggridError> {
-    Ok(fs::read_to_string(path).map_err(|e| DggridError::FileRead {
-        path: path.display().to_string(),
-        source: e,
-    })?)
-}
-
-pub fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
-where
-    P: AsRef<Path>,
-{
-    let file = File::open(filename)?;
-    Ok(io::BufReader::new(file).lines())
-}
-
-pub fn bbox_to_aigen(bbox: &Rect<f64>, bboxfile: &PathBuf) -> io::Result<()> {
-    let min = bbox.min();
-    let max = bbox.max();
-
-    let (minx, miny) = (min.x, min.y);
-    let (maxx, maxy) = (max.x, max.y);
-
-    // define the 5 vertices (closing the polygon)
-    let vertices = vec![
-        (minx, miny), // lower-left
-        (maxx, miny), // lower-right
-        (maxx, maxy), // upper-right
-        (minx, maxy), // upper-left
-        (minx, miny), // close
-    ];
-    let mut file = fs::File::create(bboxfile)?;
-
-    // First line: ID and center of the bbox (NOT part of the ring)
-    let center_x = (minx + maxx) / 2.0;
-    let center_y = (miny + maxy) / 2.0;
-    writeln!(file, "1 {:.7} {:.7}", center_x, center_y)?;
-
-    for (x, y) in &vertices {
-        writeln!(file, "{:.7} {:.7}", x, y)?;
-    }
-
-    writeln!(file, "END")?;
-    writeln!(file, "END")?;
-
-    Ok(())
 }

--- a/dggrs/src/adapters/dggrid/common.rs
+++ b/dggrs/src/adapters/dggrid/common.rs
@@ -36,6 +36,7 @@ pub mod dggrid {
 
 pub mod write {
     use crate::models::common::RefinementLevel;
+    use crate::ports::dggrs::DggrsPortConfig;
     use geo::Rect;
     use std::fs;
     use std::io::{self, Write};
@@ -50,7 +51,7 @@ pub mod write {
         cell_output_file_name: &PathBuf,
         children_output_file_name: &PathBuf,
         neighbor_output_file_name: &PathBuf,
-        densify: bool,
+        conf: &DggrsPortConfig,
     ) -> io::Result<()> {
         debug!("Writing to {:?}", metafile);
         let mut file = fs::File::create(metafile)?;
@@ -60,7 +61,7 @@ pub mod write {
         writeln!(file, "output_cell_label_type OUTPUT_ADDRESS_TYPE")?;
         writeln!(file, "precision 7")?;
         writeln!(file, "dggs_res_spec {}", refinement_level.get())?;
-        writeln!(file, "z3_invalid_digit 3")?;
+        writeln!(file, "z3_invalid_digit 3")?; // TODO: Remove with DGGRID version 9 as this is  only relevant for ISEA3H and only placed here for convenience.
 
         writeln!(
             file,
@@ -68,20 +69,25 @@ pub mod write {
             cell_output_file_name.to_string_lossy().into_owned()
         )?;
 
-        writeln!(file, "neighbor_output_type TEXT")?;
-        writeln!(
-            file,
-            "neighbor_output_file_name {}",
-            neighbor_output_file_name.to_string_lossy().into_owned()
-        )?;
-        writeln!(file, "children_output_type TEXT")?;
-        writeln!(
-            file,
-            "children_output_file_name {}",
-            children_output_file_name.to_string_lossy().into_owned()
-        )?;
+        if conf.neighbors {
+            writeln!(file, "neighbor_output_type TEXT")?;
+            writeln!(
+                file,
+                "neighbor_output_file_name {}",
+                neighbor_output_file_name.to_string_lossy().into_owned()
+            )?;
+        }
 
-        if densify == true {
+        if conf.children {
+            writeln!(file, "children_output_type TEXT")?;
+            writeln!(
+                file,
+                "children_output_file_name {}",
+                children_output_file_name.to_string_lossy().into_owned()
+            )?;
+        }
+
+        if conf.densify {
             writeln!(file, "densification {}", DENSIFICATION)?;
         }
 

--- a/dggrs/src/adapters/dggrid/common.rs
+++ b/dggrs/src/adapters/dggrid/common.rs
@@ -153,11 +153,12 @@ pub fn parse_aigen(data: &String) -> Result<Zones, GeoPlegmaError> {
 
             let zone = Zone {
                 id: zone_id.clone(),
-                region: ply,
-                center: pnt,
-                vertex_count: v_count - 1,
-                children: None,
-                neighbors: None,
+                region: Some(ply),
+                center: Some(pnt),
+                vertex_count: Some(v_count - 1),
+                children: Some(children),
+                neighbors: Some(neighbors),
+                area_sqm: Some(area_sqm),
             };
             zones.zones.push(zone);
 

--- a/dggrs/src/adapters/dggrid/dggrid.rs
+++ b/dggrs/src/adapters/dggrid/dggrid.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/dggrid/igeo7.rs
+++ b/dggrs/src/adapters/dggrid/igeo7.rs
@@ -53,9 +53,9 @@ impl DggrsPort for Igeo7Impl {
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
-            common::dggrid_setup(&self.adapter.workdir);
+            common::dggrid::setup(&self.adapter.workdir);
 
-        let _ = common::dggrid_metafile(
+        let _ = common::write::metafile(
             &meta_path,
             &refinement_level,
             &aigen_path.with_extension(""),
@@ -67,7 +67,7 @@ impl DggrsPort for Igeo7Impl {
         let _ = igeo7_metafile(&meta_path);
 
         if let Some(bbox) = &bbox {
-            let _ = common::bbox_to_aigen(bbox, &bbox_path);
+            let _ = common::write::bbox(bbox, &bbox_path);
 
             // Append to metafile
             let mut meta_file = OpenOptions::new()
@@ -84,10 +84,10 @@ impl DggrsPort for Igeo7Impl {
             );
         }
 
-        common::print_file(meta_path.clone());
-        common::dggrid_execute(&self.adapter.executable, &meta_path);
-        let result = common::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
-        common::dggrid_cleanup(
+        common::write::file(meta_path.clone());
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
+        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        common::cleanup(
             &meta_path,
             &aigen_path,
             &children_path,
@@ -105,9 +105,9 @@ impl DggrsPort for Igeo7Impl {
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
-            common::dggrid_setup(&self.adapter.workdir);
+            common::dggrid::setup(&self.adapter.workdir);
 
-        let _ = common::dggrid_metafile(
+        let _ = common::write::metafile(
             &meta_path,
             &refinement_level,
             &aigen_path.with_extension(""),
@@ -143,10 +143,10 @@ impl DggrsPort for Igeo7Impl {
         let _ = writeln!(input_file, "{} {}", point.y(), point.x())
             .expect("Cannot create point input file");
 
-        common::print_file(meta_path.clone());
-        common::dggrid_execute(&self.adapter.executable, &meta_path);
-        let result = common::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
-        common::dggrid_cleanup(
+        common::write::file(meta_path.clone());
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
+        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        common::cleanup(
             &meta_path,
             &aigen_path,
             &children_path,
@@ -164,12 +164,12 @@ impl DggrsPort for Igeo7Impl {
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
-            common::dggrid_setup(&self.adapter.workdir);
+            common::dggrid::setup(&self.adapter.workdir);
 
         let parent_zone_res = get_refinement_level_from_z7_zone_id(&parent_zone_id)?;
         let target_level = parent_zone_res.add(relative_depth)?;
 
-        let _ = common::dggrid_metafile(
+        let _ = common::write::metafile(
             &meta_path,
             &target_level,
             &aigen_path.with_extension(""),
@@ -196,12 +196,12 @@ impl DggrsPort for Igeo7Impl {
         );
         let _ = writeln!(meta_file, "clip_cell_addresses \"{}\"", parent_zone_id);
         let _ = writeln!(meta_file, "input_address_type Z7");
-        common::print_file(meta_path.clone());
-        common::dggrid_execute(&self.adapter.executable, &meta_path);
+        common::write::file(meta_path.clone());
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
 
-        let result = common::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
 
-        common::dggrid_cleanup(
+        common::cleanup(
             &meta_path,
             &aigen_path,
             &children_path,
@@ -217,10 +217,10 @@ impl DggrsPort for Igeo7Impl {
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
-            common::dggrid_setup(&self.adapter.workdir);
+            common::dggrid::setup(&self.adapter.workdir);
 
         let refinement_level = get_refinement_level_from_z7_zone_id(&zone_id).unwrap();
-        let _ = common::dggrid_metafile(
+        let _ = common::write::metafile(
             &meta_path,
             &refinement_level,
             &aigen_path.with_extension(""),
@@ -255,10 +255,10 @@ impl DggrsPort for Igeo7Impl {
 
         let _ = writeln!(meta_file, "dggrid_operation TRANSFORM_POINTS");
         let _ = writeln!(meta_file, "input_address_type Z7");
-        common::print_file(meta_path.clone());
-        common::dggrid_execute(&self.adapter.executable, &meta_path);
-        let result = common::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
-        common::dggrid_cleanup(
+        common::write::file(meta_path.clone());
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
+        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        common::cleanup(
             &meta_path,
             &aigen_path,
             &children_path,

--- a/dggrs/src/adapters/dggrid/igeo7.rs
+++ b/dggrs/src/adapters/dggrid/igeo7.rs
@@ -86,8 +86,7 @@ impl DggrsPort for Igeo7Impl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result =
-            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -146,8 +145,7 @@ impl DggrsPort for Igeo7Impl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result =
-            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -201,8 +199,7 @@ impl DggrsPort for Igeo7Impl {
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
 
-        let result =
-            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
 
         common::cleanup(
             &meta_path,
@@ -260,8 +257,7 @@ impl DggrsPort for Igeo7Impl {
         let _ = writeln!(meta_file, "input_address_type Z7");
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result =
-            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,

--- a/dggrs/src/adapters/dggrid/igeo7.rs
+++ b/dggrs/src/adapters/dggrid/igeo7.rs
@@ -61,7 +61,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.densify,
+            &cfg,
         );
 
         let _ = igeo7_metafile(&meta_path);
@@ -113,7 +113,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.densify,
+            &cfg,
         );
 
         let _ = igeo7_metafile(&meta_path);
@@ -175,7 +175,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.densify,
+            &cfg,
         );
 
         let _ = igeo7_metafile(&meta_path);
@@ -226,7 +226,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.densify,
+            &cfg,
         );
 
         let _ = igeo7_metafile(&meta_path);

--- a/dggrs/src/adapters/dggrid/igeo7.rs
+++ b/dggrs/src/adapters/dggrid/igeo7.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/dggrid/igeo7.rs
+++ b/dggrs/src/adapters/dggrid/igeo7.rs
@@ -12,7 +12,7 @@ use crate::adapters::dggrid::dggrid::DggridAdapter;
 use crate::error::dggrid::DggridError;
 use crate::error::port::GeoPlegmaError;
 use crate::models::common::{RefinementLevel, RelativeDepth, ZoneId, Zones};
-use crate::ports::dggrs::DggrsPort;
+use crate::ports::dggrs::{DggrsPort, DggrsPortConfig};
 use core::f64;
 use geo::geometry::Point;
 use std::fs;
@@ -48,9 +48,10 @@ impl DggrsPort for Igeo7Impl {
     fn zones_from_bbox(
         &self,
         refinement_level: RefinementLevel,
-        densify: bool,
         bbox: Option<Rect<f64>>,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
             common::dggrid_setup(&self.adapter.workdir);
 
@@ -60,7 +61,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            densify,
+            cfg.geometry_densification,
         );
 
         let _ = igeo7_metafile(&meta_path);
@@ -100,8 +101,9 @@ impl DggrsPort for Igeo7Impl {
         &self,
         refinement_level: RefinementLevel,
         point: Point,
-        densify: bool,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
             common::dggrid_setup(&self.adapter.workdir);
 
@@ -111,7 +113,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            densify,
+            cfg.geometry_densification,
         );
 
         let _ = igeo7_metafile(&meta_path);
@@ -158,8 +160,9 @@ impl DggrsPort for Igeo7Impl {
         &self,
         relative_depth: RelativeDepth,
         parent_zone_id: ZoneId,
-        densify: bool,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
             common::dggrid_setup(&self.adapter.workdir);
 
@@ -172,7 +175,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            densify,
+            cfg.geometry_densification,
         );
 
         let _ = igeo7_metafile(&meta_path);
@@ -207,7 +210,12 @@ impl DggrsPort for Igeo7Impl {
         );
         Ok(result)
     }
-    fn zone_from_id(&self, zone_id: ZoneId, densify: bool) -> Result<Zones, GeoPlegmaError> {
+    fn zone_from_id(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsPortConfig>,
+    ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
             common::dggrid_setup(&self.adapter.workdir);
 
@@ -218,7 +226,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            densify,
+            cfg.geometry_densification,
         );
 
         let _ = igeo7_metafile(&meta_path);

--- a/dggrs/src/adapters/dggrid/igeo7.rs
+++ b/dggrs/src/adapters/dggrid/igeo7.rs
@@ -86,7 +86,7 @@ impl DggrsPort for Igeo7Impl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -145,7 +145,7 @@ impl DggrsPort for Igeo7Impl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -199,7 +199,7 @@ impl DggrsPort for Igeo7Impl {
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
 
-        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
 
         common::cleanup(
             &meta_path,
@@ -257,7 +257,7 @@ impl DggrsPort for Igeo7Impl {
         let _ = writeln!(meta_file, "input_address_type Z7");
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
         common::cleanup(
             &meta_path,
             &aigen_path,

--- a/dggrs/src/adapters/dggrid/igeo7.rs
+++ b/dggrs/src/adapters/dggrid/igeo7.rs
@@ -86,7 +86,8 @@ impl DggrsPort for Igeo7Impl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
+        let result =
+            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -145,7 +146,8 @@ impl DggrsPort for Igeo7Impl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
+        let result =
+            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -199,7 +201,8 @@ impl DggrsPort for Igeo7Impl {
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
 
-        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
+        let result =
+            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
 
         common::cleanup(
             &meta_path,
@@ -257,7 +260,8 @@ impl DggrsPort for Igeo7Impl {
         let _ = writeln!(meta_file, "input_address_type Z7");
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
+        let result =
+            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,

--- a/dggrs/src/adapters/dggrid/igeo7.rs
+++ b/dggrs/src/adapters/dggrid/igeo7.rs
@@ -61,7 +61,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.geometry_densification,
+            cfg.densify,
         );
 
         let _ = igeo7_metafile(&meta_path);
@@ -113,7 +113,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.geometry_densification,
+            cfg.densify,
         );
 
         let _ = igeo7_metafile(&meta_path);
@@ -175,7 +175,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.geometry_densification,
+            cfg.densify,
         );
 
         let _ = igeo7_metafile(&meta_path);
@@ -226,7 +226,7 @@ impl DggrsPort for Igeo7Impl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.geometry_densification,
+            cfg.densify,
         );
 
         let _ = igeo7_metafile(&meta_path);

--- a/dggrs/src/adapters/dggrid/isea3h.rs
+++ b/dggrs/src/adapters/dggrid/isea3h.rs
@@ -12,7 +12,7 @@ use crate::adapters::dggrid::dggrid::DggridAdapter;
 use crate::error::dggrid::DggridError;
 use crate::error::port::GeoPlegmaError;
 use crate::models::common::{RefinementLevel, RelativeDepth, ZoneId, Zones};
-use crate::ports::dggrs::DggrsPort;
+use crate::ports::dggrs::{DggrsPort, DggrsPortConfig};
 use core::f64;
 use geo::{Point, Rect};
 use std::fs;
@@ -47,9 +47,10 @@ impl DggrsPort for Isea3hImpl {
     fn zones_from_bbox(
         &self,
         refinement_level: RefinementLevel,
-        densify: bool,
         bbox: Option<Rect<f64>>,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
             common::dggrid_setup(&self.adapter.workdir);
 
@@ -59,7 +60,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            densify,
+            cfg.geometry_densification,
         );
 
         let _ = isea3h_metafile(&meta_path);
@@ -99,8 +100,9 @@ impl DggrsPort for Isea3hImpl {
         &self,
         refinement_level: RefinementLevel,
         point: Point,
-        densify: bool,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
             common::dggrid_setup(&self.adapter.workdir);
 
@@ -110,7 +112,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            densify,
+            cfg.geometry_densification,
         );
 
         let _ = isea3h_metafile(&meta_path);
@@ -157,8 +159,9 @@ impl DggrsPort for Isea3hImpl {
         &self,
         relative_depth: RelativeDepth,
         parent_zone_id: ZoneId,
-        densify: bool,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
             common::dggrid_setup(&self.adapter.workdir);
 
@@ -171,7 +174,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            densify,
+            cfg.geometry_densification,
         );
 
         let _ = isea3h_metafile(&meta_path);
@@ -204,7 +207,12 @@ impl DggrsPort for Isea3hImpl {
         );
         Ok(result)
     }
-    fn zone_from_id(&self, zone_id: ZoneId, densify: bool) -> Result<Zones, GeoPlegmaError> {
+    fn zone_from_id(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsPortConfig>,
+    ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
             common::dggrid_setup(&self.adapter.workdir);
 
@@ -215,7 +223,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            densify,
+            cfg.geometry_densification,
         );
 
         let _ = isea3h_metafile(&meta_path);

--- a/dggrs/src/adapters/dggrid/isea3h.rs
+++ b/dggrs/src/adapters/dggrid/isea3h.rs
@@ -60,7 +60,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.densify,
+            &cfg,
         );
 
         let _ = isea3h_metafile(&meta_path);
@@ -112,7 +112,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.densify,
+            &cfg,
         );
 
         let _ = isea3h_metafile(&meta_path);
@@ -174,7 +174,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.densify,
+            &cfg,
         );
 
         let _ = isea3h_metafile(&meta_path);
@@ -223,7 +223,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.densify,
+            &cfg,
         );
 
         let _ = isea3h_metafile(&meta_path);

--- a/dggrs/src/adapters/dggrid/isea3h.rs
+++ b/dggrs/src/adapters/dggrid/isea3h.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/dggrid/isea3h.rs
+++ b/dggrs/src/adapters/dggrid/isea3h.rs
@@ -85,7 +85,8 @@ impl DggrsPort for Isea3hImpl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
+        let result =
+            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -144,7 +145,8 @@ impl DggrsPort for Isea3hImpl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
+        let result =
+            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -197,7 +199,8 @@ impl DggrsPort for Isea3hImpl {
         let _ = writeln!(meta_file, "input_address_type Z3");
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
+        let result =
+            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -254,7 +257,8 @@ impl DggrsPort for Isea3hImpl {
         let _ = writeln!(meta_file, "input_address_type Z3");
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
+        let result =
+            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,

--- a/dggrs/src/adapters/dggrid/isea3h.rs
+++ b/dggrs/src/adapters/dggrid/isea3h.rs
@@ -85,8 +85,7 @@ impl DggrsPort for Isea3hImpl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result =
-            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -145,8 +144,7 @@ impl DggrsPort for Isea3hImpl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result =
-            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -199,8 +197,7 @@ impl DggrsPort for Isea3hImpl {
         let _ = writeln!(meta_file, "input_address_type Z3");
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result =
-            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -257,8 +254,7 @@ impl DggrsPort for Isea3hImpl {
         let _ = writeln!(meta_file, "input_address_type Z3");
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result =
-            common::read::ingest_output(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
         common::cleanup(
             &meta_path,
             &aigen_path,

--- a/dggrs/src/adapters/dggrid/isea3h.rs
+++ b/dggrs/src/adapters/dggrid/isea3h.rs
@@ -52,9 +52,9 @@ impl DggrsPort for Isea3hImpl {
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
-            common::dggrid_setup(&self.adapter.workdir);
+            common::dggrid::setup(&self.adapter.workdir);
 
-        let _ = common::dggrid_metafile(
+        let _ = common::write::metafile(
             &meta_path,
             &refinement_level,
             &aigen_path.with_extension(""),
@@ -66,7 +66,7 @@ impl DggrsPort for Isea3hImpl {
         let _ = isea3h_metafile(&meta_path);
 
         if let Some(bbox) = &bbox {
-            let _ = common::bbox_to_aigen(bbox, &bbox_path);
+            let _ = common::write::bbox(bbox, &bbox_path);
 
             // Append to metafile
             let mut meta_file = OpenOptions::new()
@@ -83,10 +83,10 @@ impl DggrsPort for Isea3hImpl {
             );
         }
 
-        common::print_file(meta_path.clone());
-        common::dggrid_execute(&self.adapter.executable, &meta_path);
-        let result = common::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
-        common::dggrid_cleanup(
+        common::write::file(meta_path.clone());
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
+        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        common::cleanup(
             &meta_path,
             &aigen_path,
             &children_path,
@@ -104,9 +104,9 @@ impl DggrsPort for Isea3hImpl {
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
-            common::dggrid_setup(&self.adapter.workdir);
+            common::dggrid::setup(&self.adapter.workdir);
 
-        let _ = common::dggrid_metafile(
+        let _ = common::write::metafile(
             &meta_path,
             &refinement_level,
             &aigen_path.with_extension(""),
@@ -142,10 +142,10 @@ impl DggrsPort for Isea3hImpl {
         let _ = writeln!(input_file, "{} {}", point.y(), point.x())
             .expect("Cannot create point input file");
 
-        common::print_file(meta_path.clone());
-        common::dggrid_execute(&self.adapter.executable, &meta_path);
-        let result = common::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
-        common::dggrid_cleanup(
+        common::write::file(meta_path.clone());
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
+        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        common::cleanup(
             &meta_path,
             &aigen_path,
             &children_path,
@@ -163,12 +163,12 @@ impl DggrsPort for Isea3hImpl {
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, _input_path) =
-            common::dggrid_setup(&self.adapter.workdir);
+            common::dggrid::setup(&self.adapter.workdir);
 
         let parent_zone_res = get_refinement_level_from_z3_zone_id(&parent_zone_id)?;
         let target_level = parent_zone_res.add(relative_depth)?;
 
-        let _ = common::dggrid_metafile(
+        let _ = common::write::metafile(
             &meta_path,
             &target_level,
             &aigen_path.with_extension(""),
@@ -195,10 +195,10 @@ impl DggrsPort for Isea3hImpl {
         );
         let _ = writeln!(meta_file, "clip_cell_addresses \"{}\"", parent_zone_id);
         let _ = writeln!(meta_file, "input_address_type Z3");
-        common::print_file(meta_path.clone());
-        common::dggrid_execute(&self.adapter.executable, &meta_path);
-        let result = common::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
-        common::dggrid_cleanup(
+        common::write::file(meta_path.clone());
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
+        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        common::cleanup(
             &meta_path,
             &aigen_path,
             &children_path,
@@ -214,10 +214,10 @@ impl DggrsPort for Isea3hImpl {
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
         let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
-            common::dggrid_setup(&self.adapter.workdir);
+            common::dggrid::setup(&self.adapter.workdir);
 
         let refinement_level = get_refinement_level_from_z3_zone_id(&zone_id)?;
-        let _ = common::dggrid_metafile(
+        let _ = common::write::metafile(
             &meta_path,
             &refinement_level,
             &aigen_path.with_extension(""),
@@ -252,10 +252,10 @@ impl DggrsPort for Isea3hImpl {
 
         let _ = writeln!(meta_file, "dggrid_operation TRANSFORM_POINTS");
         let _ = writeln!(meta_file, "input_address_type Z3");
-        common::print_file(meta_path.clone());
-        common::dggrid_execute(&self.adapter.executable, &meta_path);
-        let result = common::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
-        common::dggrid_cleanup(
+        common::write::file(meta_path.clone());
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
+        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        common::cleanup(
             &meta_path,
             &aigen_path,
             &children_path,

--- a/dggrs/src/adapters/dggrid/isea3h.rs
+++ b/dggrs/src/adapters/dggrid/isea3h.rs
@@ -60,7 +60,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.geometry_densification,
+            cfg.densify,
         );
 
         let _ = isea3h_metafile(&meta_path);
@@ -112,7 +112,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.geometry_densification,
+            cfg.densify,
         );
 
         let _ = isea3h_metafile(&meta_path);
@@ -174,7 +174,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.geometry_densification,
+            cfg.densify,
         );
 
         let _ = isea3h_metafile(&meta_path);
@@ -223,7 +223,7 @@ impl DggrsPort for Isea3hImpl {
             &aigen_path.with_extension(""),
             &children_path.with_extension(""),
             &neighbor_path.with_extension(""),
-            cfg.geometry_densification,
+            cfg.densify,
         );
 
         let _ = isea3h_metafile(&meta_path);

--- a/dggrs/src/adapters/dggrid/isea3h.rs
+++ b/dggrs/src/adapters/dggrid/isea3h.rs
@@ -85,7 +85,7 @@ impl DggrsPort for Isea3hImpl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -144,7 +144,7 @@ impl DggrsPort for Isea3hImpl {
 
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -197,7 +197,7 @@ impl DggrsPort for Isea3hImpl {
         let _ = writeln!(meta_file, "input_address_type Z3");
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
         common::cleanup(
             &meta_path,
             &aigen_path,
@@ -254,7 +254,7 @@ impl DggrsPort for Isea3hImpl {
         let _ = writeln!(meta_file, "input_address_type Z3");
         common::write::file(meta_path.clone());
         common::dggrid::execute(&self.adapter.executable, &meta_path);
-        let result = common::read::dggrid_parse(&aigen_path, &children_path, &neighbor_path)?;
+        let result = common::read::ingest_output(&aigen_path, &children_path, &neighbor_path)?;
         common::cleanup(
             &meta_path,
             &aigen_path,

--- a/dggrs/src/adapters/dggrid/mod.rs
+++ b/dggrs/src/adapters/dggrid/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/h3o/common.rs
+++ b/dggrs/src/adapters/h3o/common.rs
@@ -10,8 +10,9 @@
 use crate::{
     error::{h3o::H3oError, port::GeoPlegmaError},
     models::common::{RefinementLevel, Zone, ZoneId, Zones},
+    ports::dggrs::DggrsPortConfig,
 };
-use geo::{Coord, CoordsIter, LineString, Point, Polygon};
+use geo::{Coord, CoordsIter, GeodesicArea, LineString, Point, Polygon};
 use h3o::{Boundary, CellIndex, LatLng, Resolution};
 
 /// Translates integer resolution to H3 string resolution
@@ -58,45 +59,74 @@ pub fn latlng_to_point(latlng: LatLng) -> Point {
     Point::new(latlng.lng(), latlng.lat())
 }
 
-pub fn cells_to_zones(cells: Vec<CellIndex>) -> Result<Zones, GeoPlegmaError> {
-    let zones: Vec<Zone> = cells
+pub fn to_zones(h3o_zones: Vec<CellIndex>, conf: DggrsPortConfig) -> Result<Zones, GeoPlegmaError> {
+    let zones: Vec<Zone> = h3o_zones
         .into_iter()
-        .map(|cell| {
-            let id = ZoneId::new_hex(&cell.to_string())?;
+        .map(|h3o_zone| {
+            let id = ZoneId::new_hex(&h3o_zone.to_string())?;
 
-            let center = LatLng::from(cell);
-            let center_point = latlng_to_point(center); // geo::Point
+            let center = if conf.center {
+                let ll = LatLng::from(h3o_zone);
+                Some(latlng_to_point(ll)) // geo::Point
+            } else {
+                None
+            };
 
-            let boundary = cell.boundary();
-            let region = boundary_to_polygon(&boundary); // geo::Polygon
+            let region = if conf.region || conf.area_sqm || conf.vertex_count {
+                let boundary = h3o_zone.boundary();
+                Some(boundary_to_polygon(&boundary)) // geo::Polygon
+            } else {
+                None
+            };
 
-            let vertex_count = region.exterior().coords_count() as u32;
+            let area_sqm = if conf.area_sqm {
+                region.as_ref().map(|r| r.geodesic_area_unsigned())
+            } else {
+                None
+            };
 
-            let child_res = cell
-                .resolution()
-                .succ() // succ() returns an Option, therefore we can use ok_or_else in the next line and not map_err
-                .ok_or_else(|| H3oError::ResolutionLimitReached {
-                    zone_id: cell.to_string(),
-                })?;
+            let vertex_count = if conf.vertex_count {
+                region.as_ref().map(|r| r.exterior().coords_count() as u32)
+            } else {
+                None
+            };
 
-            let children_opt: Vec<ZoneId> = cell
-                .children(child_res)
-                .map(|c| ZoneId::new_hex(&c.to_string()))
-                .collect::<Result<_, _>>()?; // NOTE: In Result<_ , _>> the _ means that the T and E are inferred. 
+            let children = if conf.children {
+                let chr_res = h3o_zone
+                    .resolution()
+                    .succ() // succ() returns an Option, therefore we can use ok_or_else in the next line and not map_err
+                    .ok_or_else(|| H3oError::ResolutionLimitReached {
+                        zone_id: h3o_zone.to_string(),
+                    })?;
 
-            let neighbors_opt: Vec<ZoneId> = cell
-                .grid_disk::<Vec<CellIndex>>(1)
-                .into_iter()
-                .map(|c| ZoneId::new_hex(&c.to_string()))
-                .collect::<Result<_, _>>()?; // NOTE: In Result<_ , _>> the _ means that the T and E are inferred. 
+                let chr_vec: Vec<ZoneId> = h3o_zone
+                    .children(chr_res)
+                    .map(|c| ZoneId::new_hex(&c.to_string()))
+                    .collect::<Result<_, _>>()?; // NOTE: In Result<_ , _>> the _ means that the T and E are inferred. 
+                Some(chr_vec)
+            } else {
+                None
+            };
+
+            let neighbors = if conf.neighbors {
+                let nbr: Vec<ZoneId> = h3o_zone
+                    .grid_disk::<Vec<CellIndex>>(1)
+                    .into_iter()
+                    .map(|c| ZoneId::new_hex(&c.to_string()))
+                    .collect::<Result<_, _>>()?; // NOTE: In Result<_ , _>> the _ means that the T and E are inferred. 
+                Some(nbr)
+            } else {
+                None
+            };
 
             Ok(Zone {
                 id,
                 region,
+                center,
                 vertex_count,
-                center: center_point,
-                children: Some(children_opt),
-                neighbors: Some(neighbors_opt),
+                children,
+                neighbors,
+                area_sqm,
             })
         })
         .collect::<Result<Vec<Zone>, GeoPlegmaError>>()?;

--- a/dggrs/src/adapters/h3o/common.rs
+++ b/dggrs/src/adapters/h3o/common.rs
@@ -80,13 +80,13 @@ pub fn to_zones(h3o_zones: Vec<CellIndex>, conf: DggrsPortConfig) -> Result<Zone
             };
 
             let area_sqm = if conf.area_sqm {
-                region.as_ref().map(|r| r.geodesic_area_unsigned())
+                region.as_ref().map(|r| r.geodesic_area_unsigned()) // NOTE: It is also an option to use the build in area function of H3o
             } else {
                 None
             };
 
             let vertex_count = if conf.vertex_count {
-                region.as_ref().map(|r| r.exterior().coords_count() as u32)
+                region.as_ref().map(|r| r.exterior().coords_count() as u32) // NOTE: It is also an option to use the build-in vertex function of H3o
             } else {
                 None
             };
@@ -94,7 +94,7 @@ pub fn to_zones(h3o_zones: Vec<CellIndex>, conf: DggrsPortConfig) -> Result<Zone
             let children = if conf.children {
                 let chr_res = h3o_zone
                     .resolution()
-                    .succ() // succ() returns an Option, therefore we can use ok_or_else in the next line and not map_err
+                    .succ() // NOTE: succ() returns an Option, therefore we can use ok_or_else in the next line and not map_err
                     .ok_or_else(|| H3oError::ResolutionLimitReached {
                         zone_id: h3o_zone.to_string(),
                     })?;

--- a/dggrs/src/adapters/h3o/common.rs
+++ b/dggrs/src/adapters/h3o/common.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/h3o/h3.rs
+++ b/dggrs/src/adapters/h3o/h3.rs
@@ -7,7 +7,7 @@
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::adapters::h3o::common::{cells_to_zones, refinement_level_to_h3_resolution};
+use crate::adapters::h3o::common::{refinement_level_to_h3_resolution, to_zones};
 use crate::adapters::h3o::h3o::H3oAdapter;
 use crate::error::h3o::H3oError;
 use crate::error::port::GeoPlegmaError;
@@ -15,7 +15,7 @@ use crate::models::common::{RefinementLevel, RelativeDepth, ZoneId, Zones};
 use crate::ports::dggrs::{DggrsPort, DggrsPortConfig};
 use geo::{Point, Rect};
 use h3o::geom::{ContainmentMode, TilerBuilder};
-use h3o::{CellIndex, LatLng, Resolution};
+use h3o::{CellIndex, LatLng};
 use std::str::FromStr;
 
 pub const MAX_DEPTH: u8 = 10;
@@ -48,7 +48,7 @@ impl DggrsPort for H3Impl {
         config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
-        let cells: Vec<CellIndex>;
+        let h3o_zones: Vec<CellIndex>;
 
         let mut tiler =
             TilerBuilder::new(refinement_level_to_h3_resolution(RefinementLevel::new(2)?)?)
@@ -58,12 +58,12 @@ impl DggrsPort for H3Impl {
         if let Some(b) = bbox {
             // NOTE: adapt resolution dynamically based on bbox size & depth
             let _ = tiler.add(b.to_polygon());
-            cells = tiler.into_coverage().collect::<Vec<_>>();
+            h3o_zones = tiler.into_coverage().collect::<Vec<_>>();
         } else {
             if refinement_level > self.default_refinement_level()? {
                 return Err(GeoPlegmaError::DepthTooLarge(refinement_level));
             }
-            cells = CellIndex::base_cells()
+            h3o_zones = CellIndex::base_cells()
                 .flat_map(|base| {
                     base.children(
                         refinement_level_to_h3_resolution(refinement_level)
@@ -72,7 +72,7 @@ impl DggrsPort for H3Impl {
                 })
                 .collect::<Vec<_>>();
         }
-        Ok(cells_to_zones(cells)?)
+        Ok(to_zones(h3o_zones, cfg)?)
     }
     fn zone_from_point(
         &self,
@@ -83,9 +83,9 @@ impl DggrsPort for H3Impl {
         let cfg = config.unwrap_or_default();
         let coord = LatLng::new(point.x(), point.y()).expect("valid coord");
 
-        let cell = coord.to_cell(refinement_level_to_h3_resolution(refinement_level)?);
+        let h3o_zone = coord.to_cell(refinement_level_to_h3_resolution(refinement_level)?);
 
-        Ok(cells_to_zones(vec![cell])?)
+        Ok(to_zones(vec![h3o_zone], cfg)?)
     }
     fn zones_from_parent(
         &self,
@@ -109,11 +109,11 @@ impl DggrsPort for H3Impl {
             }));
         }
 
-        let children: Vec<CellIndex> = parent
+        let h3o_sub_zones: Vec<CellIndex> = parent
             .children(refinement_level_to_h3_resolution(target_level)?)
             .collect();
 
-        Ok(cells_to_zones(children)?)
+        Ok(to_zones(h3o_sub_zones, cfg)?)
     }
     fn zone_from_id(
         &self,
@@ -121,14 +121,14 @@ impl DggrsPort for H3Impl {
         config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
         let cfg = config.unwrap_or_default();
-        let cell = CellIndex::from_str(&zone_id.to_string()).map_err(|e| {
+        let h3o_zone = CellIndex::from_str(&zone_id.to_string()).map_err(|e| {
             GeoPlegmaError::H3o(H3oError::InvalidZoneID {
                 zone_id: zone_id.to_string(),
                 source: e,
             })
         })?;
 
-        Ok(cells_to_zones(vec![cell])?)
+        Ok(to_zones(vec![h3o_zone], cfg)?)
     }
 
     fn min_refinement_level(&self) -> Result<RefinementLevel, GeoPlegmaError> {

--- a/dggrs/src/adapters/h3o/h3.rs
+++ b/dggrs/src/adapters/h3o/h3.rs
@@ -12,7 +12,7 @@ use crate::adapters::h3o::h3o::H3oAdapter;
 use crate::error::h3o::H3oError;
 use crate::error::port::GeoPlegmaError;
 use crate::models::common::{RefinementLevel, RelativeDepth, ZoneId, Zones};
-use crate::ports::dggrs::DggrsPort;
+use crate::ports::dggrs::{DggrsPort, DggrsPortConfig};
 use geo::{Point, Rect};
 use h3o::geom::{ContainmentMode, TilerBuilder};
 use h3o::{CellIndex, LatLng, Resolution};
@@ -44,9 +44,10 @@ impl DggrsPort for H3Impl {
     fn zones_from_bbox(
         &self,
         refinement_level: RefinementLevel,
-        _densify: bool,
         bbox: Option<Rect<f64>>,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let cells: Vec<CellIndex>;
 
         let mut tiler =
@@ -77,8 +78,9 @@ impl DggrsPort for H3Impl {
         &self,
         refinement_level: RefinementLevel,
         point: Point, // TODO: we should support multiple points at once.
-        _densify: bool,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let coord = LatLng::new(point.x(), point.y()).expect("valid coord");
 
         let cell = coord.to_cell(refinement_level_to_h3_resolution(refinement_level)?);
@@ -89,8 +91,9 @@ impl DggrsPort for H3Impl {
         &self,
         relative_depth: RelativeDepth,
         parent_zone_id: ZoneId,
-        _densify: bool,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let parent = CellIndex::from_str(&parent_zone_id.to_string()).map_err(|e| {
             GeoPlegmaError::H3o(H3oError::InvalidZoneID {
                 zone_id: parent_zone_id.to_string(),
@@ -115,8 +118,9 @@ impl DggrsPort for H3Impl {
     fn zone_from_id(
         &self,
         zone_id: ZoneId, // ToDo: needs validation function
-        _densify: bool,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError> {
+        let cfg = config.unwrap_or_default();
         let cell = CellIndex::from_str(&zone_id.to_string()).map_err(|e| {
             GeoPlegmaError::H3o(H3oError::InvalidZoneID {
                 zone_id: zone_id.to_string(),

--- a/dggrs/src/adapters/h3o/h3.rs
+++ b/dggrs/src/adapters/h3o/h3.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/h3o/h3o.rs
+++ b/dggrs/src/adapters/h3o/h3o.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/h3o/mod.rs
+++ b/dggrs/src/adapters/h3o/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/mod.rs
+++ b/dggrs/src/adapters/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/adapters/rhealpix/mod.rs
+++ b/dggrs/src/adapters/rhealpix/mod.rs
@@ -1,9 +1,8 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
 // <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms.
-

--- a/dggrs/src/adapters/rhealpix/rhealpix.rs
+++ b/dggrs/src/adapters/rhealpix/rhealpix.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/constants.rs
+++ b/dggrs/src/constants.rs
@@ -1,3 +1,12 @@
+// Copyright 2025 contributors to the GeoPlegmata project.
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
+//
+// Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
+// discretion. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use geo::{Coord, Rect};
 
 pub fn whole_earth_bbox() -> Rect<f64> {

--- a/dggrs/src/error/dggal.rs
+++ b/dggrs/src/error/dggal.rs
@@ -7,7 +7,6 @@
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::models::common::{RefinementLevel, RelativeDepth};
 use std::num::TryFromIntError;
 use thiserror::Error;
 

--- a/dggrs/src/error/dggal.rs
+++ b/dggrs/src/error/dggal.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/error/dggrid.rs
+++ b/dggrs/src/error/dggrid.rs
@@ -33,10 +33,19 @@ pub enum DggridError {
     #[error("Missing required zone data")]
     MissingZoneData,
 
-    #[error("Failed to read file {path}: {source}")]
+    // File I/O
+    #[error("Failed to read file {path}")]
     FileRead {
         path: String,
         #[source]
         source: io::Error,
     },
+
+    // Generic I/O passthrough (when you don't need the path)
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+
+    // When the format itself is broken (no underlying source)
+    #[error("Malformed DGGRID content: {msg}")]
+    Malformed { msg: String },
 }

--- a/dggrs/src/error/dggrid.rs
+++ b/dggrs/src/error/dggrid.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/error/factory.rs
+++ b/dggrs/src/error/factory.rs
@@ -7,7 +7,6 @@
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::num::TryFromIntError;
 use thiserror::Error;
 
 /// Error type for instantiating DggrsPort adapters via the factory.

--- a/dggrs/src/error/factory.rs
+++ b/dggrs/src/error/factory.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/error/h3o.rs
+++ b/dggrs/src/error/h3o.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/error/mod.rs
+++ b/dggrs/src/error/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/error/port.rs
+++ b/dggrs/src/error/port.rs
@@ -11,6 +11,7 @@ use crate::error::dggal::DggalError;
 use crate::error::dggrid::DggridError;
 use crate::error::h3o::H3oError;
 use crate::models::common::{RefinementLevel, RelativeDepth};
+use std::num::ParseFloatError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -69,4 +70,8 @@ pub enum GeoPlegmaError {
 
     #[error("Invalid hex ZoneId: '{0}'")]
     InvalidHexId(String),
+
+    // Parsing primitives
+    #[error("Float parse error: {0}")]
+    Float(#[from] ParseFloatError),
 }

--- a/dggrs/src/error/port.rs
+++ b/dggrs/src/error/port.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegmata project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/factory/dggrs_factory.rs
+++ b/dggrs/src/factory/dggrs_factory.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/factory/mod.rs
+++ b/dggrs/src/factory/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/lib.rs
+++ b/dggrs/src/lib.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/lib.rs
+++ b/dggrs/src/lib.rs
@@ -17,3 +17,4 @@ pub mod ports;
 
 /// This is the only re-export that is needed.
 pub use factory::dggrs_factory::get;
+pub use ports::dggrs::DggrsPortConfig as config;

--- a/dggrs/src/models/common.rs
+++ b/dggrs/src/models/common.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/models/common.rs
+++ b/dggrs/src/models/common.rs
@@ -12,17 +12,18 @@ use std::convert::{From, TryFrom};
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
 pub struct Zone {
     pub id: ZoneId,
-    pub region: Polygon,
-    pub center: Point,
-    pub vertex_count: u32,
+    pub region: Option<Polygon>,
+    pub center: Option<Point>,
+    pub vertex_count: Option<u32>,
     pub children: Option<Vec<ZoneId>>,
     pub neighbors: Option<Vec<ZoneId>>,
+    pub area_sqm: Option<f64>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Default)]
 pub struct Zones {
     pub zones: Vec<Zone>,
 }

--- a/dggrs/src/models/common.rs
+++ b/dggrs/src/models/common.rs
@@ -28,14 +28,14 @@ pub struct Zones {
     pub zones: Vec<Zone>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ZoneId {
     StrId(String),
     HexId(HexString),
     IntId(u64),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct HexString(String);
 
 impl HexString {

--- a/dggrs/src/models/mod.rs
+++ b/dggrs/src/models/mod.rs
@@ -1,6 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-//
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/ports/dggrs.rs
+++ b/dggrs/src/ports/dggrs.rs
@@ -12,26 +12,30 @@ use crate::models::common::{RefinementLevel, RelativeDepth, ZoneId, Zones};
 use geo::{Point, Rect};
 
 pub struct DggrsPortConfig {
+    pub region: bool,
+    pub center: bool,
+    pub vertex_count: bool,
     pub children: bool,
     pub neighbors: bool,
-    pub geometry: bool,
-    pub area: bool,
-    pub geometry_densification: bool,
+    pub area_sqm: bool,
+    pub densify: bool,
 }
 
 impl Default for DggrsPortConfig {
     fn default() -> Self {
         Self {
-            children: false,
-            neighbors: false,
-            geometry: false,
-            area: false,
-            geometry_densification: true,
+            region: true,
+            center: true,
+            vertex_count: true,
+            children: true,
+            neighbors: true,
+            area_sqm: true,
+            densify: true,
         }
     }
 }
 
-/// The DGGRS port trait. Each adapter can only implment the functions defined here.
+/// The DGGRS port trait. Each adapter can only implement the functions defined here.
 pub trait DggrsPort: Send + Sync {
     /// Get zones for geo::Rect bounding box. If no bbox is supplied the whole world is taken.
     fn zones_from_bbox(

--- a/dggrs/src/ports/dggrs.rs
+++ b/dggrs/src/ports/dggrs.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/dggrs/src/ports/dggrs.rs
+++ b/dggrs/src/ports/dggrs.rs
@@ -11,6 +11,19 @@ use crate::error::port::GeoPlegmaError;
 use crate::models::common::{RefinementLevel, RelativeDepth, ZoneId, Zones};
 use geo::{Point, Rect};
 
+/// Addresses all the configuration options that apply to all port functions
+///
+/// Boolean switches are all set to true via the default implementation
+///
+/// The following output can be controlled:
+/// - region geometry
+/// - centroid geometry
+/// - vertex_count (the number of edges/nodes
+/// - children (list of ZoneIds)
+/// - neighbors (list of ZoneIds)
+/// - area_sqm (the area in squaremeter as calculated by `geo`'s geodesic_area_unsigned() function
+/// - densify (region geometry densification)
+///
 pub struct DggrsPortConfig {
     pub region: bool,
     pub center: bool,
@@ -18,7 +31,7 @@ pub struct DggrsPortConfig {
     pub children: bool,
     pub neighbors: bool,
     pub area_sqm: bool,
-    pub densify: bool,
+    pub densify: bool, // TODO:: this is the switch to generate densified gemetry, which is actually not needed for H3 due to the Gnomic projection.
 }
 
 impl Default for DggrsPortConfig {

--- a/dggrs/src/ports/dggrs.rs
+++ b/dggrs/src/ports/dggrs.rs
@@ -9,8 +9,27 @@
 
 use crate::error::port::GeoPlegmaError;
 use crate::models::common::{RefinementLevel, RelativeDepth, ZoneId, Zones};
-use geo::Point;
-use geo::Rect;
+use geo::{Point, Rect};
+
+pub struct DggrsPortConfig {
+    pub children: bool,
+    pub neighbors: bool,
+    pub geometry: bool,
+    pub area: bool,
+    pub geometry_densification: bool,
+}
+
+impl Default for DggrsPortConfig {
+    fn default() -> Self {
+        Self {
+            children: false,
+            neighbors: false,
+            geometry: false,
+            area: false,
+            geometry_densification: true,
+        }
+    }
+}
 
 /// The DGGRS port trait. Each adapter can only implment the functions defined here.
 pub trait DggrsPort: Send + Sync {
@@ -18,8 +37,8 @@ pub trait DggrsPort: Send + Sync {
     fn zones_from_bbox(
         &self,
         refinement_level: RefinementLevel,
-        densify: bool,
         bbox: Option<Rect<f64>>,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError>;
 
     /// Get zones for a geo::Point.
@@ -27,7 +46,7 @@ pub trait DggrsPort: Send + Sync {
         &self,
         refinement_level: RefinementLevel,
         point: Point, // NOTE:Consider accepting a vector of Points.
-        densify: bool,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError>;
 
     /// Get zones based on a parent ZoneID.
@@ -35,11 +54,15 @@ pub trait DggrsPort: Send + Sync {
         &self,
         relative_depth: RelativeDepth,
         parent_zone_id: ZoneId,
-        densify: bool,
+        config: Option<DggrsPortConfig>,
     ) -> Result<Zones, GeoPlegmaError>;
 
     /// Get a zone based on a ZoneID
-    fn zone_from_id(&self, zone_id: ZoneId, densify: bool) -> Result<Zones, GeoPlegmaError>; // NOTE: Consider accepting a vector of ZoneIDs
+    fn zone_from_id(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsPortConfig>,
+    ) -> Result<Zones, GeoPlegmaError>; // NOTE: Consider accepting a vector of ZoneIDs
 
     /// Get the minimum refinement level of a DGGRS
     fn min_refinement_level(&self) -> Result<RefinementLevel, GeoPlegmaError>;

--- a/dggrs/src/ports/mod.rs
+++ b/dggrs/src/ports/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2025 contributors to the GeoPlegma project.
-// Originally authored by Michael Jendryke (GeoInsight GmbH, michael.jendryke@geoinsight.ai)
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
 //
 // Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license


### PR DESCRIPTION
This is related to issue #33 and requires PR #52 to be merged. 

Right now the `DggrsPort` trait has function signatures with e.g. `densify: bool`

```rust
fn zone_from_id(&self, zone_id: ZoneId, densify: bool) -> Result<Zones, GeoPlegmaError>; 
```
The resulting `Zones/Zone` struct needs to be adjusted to this

```rust
#[derive(Debug, Clone, Default)]
pub struct Zone {
    pub id: ZoneId,
    pub region: Option<Polygon>,
    pub center: Option<Point>,
    pub vertex_count: Option<u32>,
    pub children: Option<Vec<ZoneId>>,
    pub neighbors: Option<Vec<ZoneId>>,
    pub area_sqm: Option<f64>,
}

#[derive(Debug, Clone, Default)]
pub struct Zones {
    pub zones: Vec<Zone>,
}
```
so that only the ZoneId is a mandatory output, all others are optional.

Tasks to be implemented for optional generation/calculation are

- [x] `region`
- [x] `center`
- [x] `vertex_count`
- [x] `children`
- [x] `neighbors`
- [x] `area`
- [x] `densify`

Into a separate struct `GeneratorConfig` (Happy to get better suggestions) with an default implementation, like this:

```rust
pub struct GeneratorConfig {
    pub children: bool,
    pub neighbors: bool,
    pub geometry: bool,
    pub area: bool,
    pub geometry_densification: bool,
}

impl Default for GeneratorConfig {
    fn default() -> Self {
        Self {
            children: false,
            neighbors: false,
            geometry: false,
            area: false,
            geometry_densification: true,
        }
    }
}
```
Let me know what defaults you would set. 

We can then call the above function with adapted configuration (in this case to get the children as well) like this:

```rust
let _ dggrs.zone_from_id(&self, zone_id: ZoneId, generator_config: GeneratorConfig {children: true, ..Default::default()}); 
```                                                                                                                                                         
