### PR TITLE
[BUG] fixing condition when to calculate area

### DIFF
--- a/api/src/adapters/dggal/common.rs
+++ b/api/src/adapters/dggal/common.rs
@@ -34,7 +34,7 @@ pub fn to_zones(
                 None
             };
 
-            let region = if conf.neighbors || conf.area_sqm {
+            let region = if conf.region || conf.area_sqm {
                 let dggal_geo_points = if conf.densify {
                     dggrs.getZoneRefinedWGS84Vertices(dggal_zone, 0)
                 } else {


### PR DESCRIPTION
The adapter would tell dggal to produce `region` when when `neighbors` OR `area` were requested. Obviously it needs to be `region` OR `area`.