### PR TITLE
Fix basic example in geoplegma

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Make sure DGGRID is compiled and available on your system. Remember the path whe
 
 ## Usage Example
 
-Check out `dggrs/example/basic.rs` for a simple example of how to use the `dggrs` crate of GeoPlegma.
+Check out `geoplegma/example/basic.rs` for a simple example of how to use the `geoplegma` crate of GeoPlegma.
 ```bash
-cd dggrs
+cd geoplegma
 cargo run --example basic
 ```
 

--- a/geoplegma/example/basic.rs
+++ b/geoplegma/example/basic.rs
@@ -6,9 +6,9 @@
 // <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms.
-use api::error;
-use api::models::common::{DggrsUid, RefinementLevel, RelativeDepth};
-use api::{get, registry};
+use geoplegma::error;
+use geoplegma::models::common::{DggrsUid, RefinementLevel, RelativeDepth};
+use geoplegma::{get, registry};
 use geo::{Point, Rect};
 use std::time::Instant;
 
@@ -38,7 +38,7 @@ pub fn main() -> Result<(), error::DggrsError> {
 
     let bbox = Rect::new(Point::new(-10.0, -10.0), Point::new(10.0, 10.0));
 
-    let mut options = api::config {
+    let mut options = geoplegma::config {
         region: true,
         children: false,
         center: false,


### PR DESCRIPTION
https://github.com/GeoPlegma/GeoPlegma/pull/86 broke the basic example. This PR:
- Fixes the imports from `api` to `geoplegma`.
- Fixes the name of the example in the README.

Steps:
- [ ] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [x] Add README documentation of what's done in the PR, if needed.
- [x] Request review
