### PR TITLE
Add primary_parent_from_zone to api

### DIFF
--- a/geoplegma/src/adapters/dggal/grids.rs
+++ b/geoplegma/src/adapters/dggal/grids.rs
@@ -123,6 +123,38 @@ impl DggrsApi for DggalImpl {
 
         Ok(to_zones(dggrs, zones, cfg)?)
     }
+
+    fn parent_from_zone(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError> {
+        let cfg = config.unwrap_or_default();
+        let dggrs = self.get_dggrs()?;
+
+        let zone_u64 = match &zone_id {
+            ZoneId::IntId(id) => *id,
+            ZoneId::StrId(s) => dggrs.getZoneFromTextID(s),
+            ZoneId::HexId(h) => dggrs.getZoneFromTextID(&h.to_string()),
+        };
+
+        if dggrs.getZoneArea(zone_u64).is_infinite() {
+            return Err(DggrsError::Dggal(DggalError::InvalidDggalZoneId));
+        }
+
+        let parent = dggrs
+            .getZoneParents(zone_u64)
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                DggrsError::Dggal(DggalError::InvalidZoneIdFormat(
+                    "Root-level zones do not have a parent".to_string(),
+                ))
+            })?;
+
+        Ok(to_zones(dggrs, vec![parent], cfg)?)
+    }
+
     fn zone_from_id(
         &self,
         zone_id: ZoneId,

--- a/geoplegma/src/adapters/dggal/grids.rs
+++ b/geoplegma/src/adapters/dggal/grids.rs
@@ -151,11 +151,18 @@ impl DggrsApi for DggalImpl {
             }
             1 => parents[0],
             _ => {
-                let first = parents[0];
-                parents
-                    .into_iter()
-                    .find(|p| dggrs.isZoneCentroidChild(*p))
-                    .unwrap_or(first)
+                if self.id.spec().aperture == 7 {
+                    parents[0]
+                } else {
+                    parents
+                        .into_iter()
+                        .find(|p| dggrs.isZoneCentroidChild(*p))
+                        .ok_or_else(|| {
+                            DggrsError::Dggal(DggalError::InvalidZoneIdFormat(
+                                "Could not determine a primary parent for this zone".to_string(),
+                            ))
+                        })?
+                }
             }
         };
 

--- a/geoplegma/src/adapters/dggal/grids.rs
+++ b/geoplegma/src/adapters/dggal/grids.rs
@@ -150,14 +150,13 @@ impl DggrsApi for DggalImpl {
                 )));
             }
             1 => parents[0],
-            _ => parents
-                .into_iter()
-                .find(|p| dggrs.isZoneCentroidChild(*p))
-                .ok_or_else(|| {
-                    DggrsError::Dggal(DggalError::InvalidZoneIdFormat(
-                        "Could not determine a primary parent for this zone".to_string(),
-                    ))
-                })?,
+            _ => {
+                let first = parents[0];
+                parents
+                    .into_iter()
+                    .find(|p| dggrs.isZoneCentroidChild(*p))
+                    .unwrap_or(first)
+            }
         };
 
         Ok(to_zones(dggrs, vec![parent], cfg)?)

--- a/geoplegma/src/adapters/dggal/grids.rs
+++ b/geoplegma/src/adapters/dggal/grids.rs
@@ -124,7 +124,7 @@ impl DggrsApi for DggalImpl {
         Ok(to_zones(dggrs, zones, cfg)?)
     }
 
-    fn parent_from_zone(
+    fn primary_parent_from_zone(
         &self,
         zone_id: ZoneId,
         config: Option<DggrsApiConfig>,
@@ -142,15 +142,23 @@ impl DggrsApi for DggalImpl {
             return Err(DggrsError::Dggal(DggalError::InvalidDggalZoneId));
         }
 
-        let parent = dggrs
-            .getZoneParents(zone_u64)
-            .into_iter()
-            .next()
-            .ok_or_else(|| {
-                DggrsError::Dggal(DggalError::InvalidZoneIdFormat(
+        let parents = dggrs.getZoneParents(zone_u64);
+        let parent = match parents.len() {
+            0 => {
+                return Err(DggrsError::Dggal(DggalError::InvalidZoneIdFormat(
                     "Root-level zones do not have a parent".to_string(),
-                ))
-            })?;
+                )));
+            }
+            1 => parents[0],
+            _ => parents
+                .into_iter()
+                .find(|p| dggrs.isZoneCentroidChild(*p))
+                .ok_or_else(|| {
+                    DggrsError::Dggal(DggalError::InvalidZoneIdFormat(
+                        "Could not determine a primary parent for this zone".to_string(),
+                    ))
+                })?,
+        };
 
         Ok(to_zones(dggrs, vec![parent], cfg)?)
     }

--- a/geoplegma/src/adapters/dggrid/igeo7.rs
+++ b/geoplegma/src/adapters/dggrid/igeo7.rs
@@ -216,6 +216,71 @@ impl DggrsApi for Igeo7Impl {
         );
         Ok(result)
     }
+
+    fn parent_from_zone(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError> {
+        let cfg = config.unwrap_or_default();
+        let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
+            common::dggrid::setup(&self.adapter.workdir);
+
+        let child_level = get_refinement_level_from_z7_zone_id(&zone_id)?;
+        if child_level.get() == 0 {
+            return Err(DggrsError::Dggrid(DggridError::InvalidZ7Format(
+                "Root-level zones do not have a parent".to_string(),
+            )));
+        }
+        let parent_level = RefinementLevel::new(child_level.get() - 1)?;
+
+        let _ = common::write::metafile(
+            &meta_path,
+            &parent_level,
+            &aigen_path.with_extension(""),
+            &children_path.with_extension(""),
+            &neighbor_path.with_extension(""),
+            &cfg,
+        );
+
+        let _ = igeo7_metafile(&meta_path);
+
+        let mut meta_file = OpenOptions::new()
+            .append(true)
+            .write(true)
+            .open(&meta_path)
+            .expect("cannot open file");
+
+        let _ = writeln!(
+            meta_file,
+            "input_file_name {}",
+            &input_path.to_string_lossy()
+        );
+
+        let mut input_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&input_path)
+            .expect("cannot open file");
+        let _ = writeln!(input_file, "{}", zone_id).expect("Cannot create zone id input file");
+
+        let _ = writeln!(meta_file, "dggrid_operation TRANSFORM_POINTS");
+        let _ = writeln!(meta_file, "input_address_type Z7");
+        common::write::file(&meta_path);
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        common::cleanup(
+            &meta_path,
+            &aigen_path,
+            &children_path,
+            &neighbor_path,
+            &bbox_path,
+            &input_path,
+        );
+        Ok(result)
+    }
+
     fn zone_from_id(
         &self,
         zone_id: ZoneId,

--- a/geoplegma/src/adapters/dggrid/igeo7.rs
+++ b/geoplegma/src/adapters/dggrid/igeo7.rs
@@ -217,7 +217,7 @@ impl DggrsApi for Igeo7Impl {
         Ok(result)
     }
 
-    fn parent_from_zone(
+    fn primary_parent_from_zone(
         &self,
         zone_id: ZoneId,
         config: Option<DggrsApiConfig>,

--- a/geoplegma/src/adapters/dggrid/isea3h.rs
+++ b/geoplegma/src/adapters/dggrid/isea3h.rs
@@ -214,7 +214,7 @@ impl DggrsApi for Isea3hImpl {
         Ok(result)
     }
 
-    fn parent_from_zone(
+    fn primary_parent_from_zone(
         &self,
         zone_id: ZoneId,
         config: Option<DggrsApiConfig>,

--- a/geoplegma/src/adapters/dggrid/isea3h.rs
+++ b/geoplegma/src/adapters/dggrid/isea3h.rs
@@ -213,6 +213,71 @@ impl DggrsApi for Isea3hImpl {
         );
         Ok(result)
     }
+
+    fn parent_from_zone(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError> {
+        let cfg = config.unwrap_or_default();
+        let (meta_path, aigen_path, children_path, neighbor_path, bbox_path, input_path) =
+            common::dggrid::setup(&self.adapter.workdir);
+
+        let child_level = get_refinement_level_from_z3_zone_id(&zone_id)?;
+        if child_level.get() == 0 {
+            return Err(DggrsError::Dggrid(DggridError::InvalidZ3Format(
+                "Root-level zones do not have a parent".to_string(),
+            )));
+        }
+        let parent_level = RefinementLevel::new(child_level.get() - 1)?;
+
+        let _ = common::write::metafile(
+            &meta_path,
+            &parent_level,
+            &aigen_path.with_extension(""),
+            &children_path.with_extension(""),
+            &neighbor_path.with_extension(""),
+            &cfg,
+        );
+
+        let _ = isea3h_metafile(&meta_path);
+
+        let mut meta_file = OpenOptions::new()
+            .append(true)
+            .write(true)
+            .open(&meta_path)
+            .expect("cannot open file");
+
+        let _ = writeln!(
+            meta_file,
+            "input_file_name {}",
+            &input_path.to_string_lossy()
+        );
+
+        let mut input_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&input_path)
+            .expect("cannot open file");
+        let _ = writeln!(input_file, "{}", zone_id).expect("Cannot create zone id input file");
+
+        let _ = writeln!(meta_file, "dggrid_operation TRANSFORM_POINTS");
+        let _ = writeln!(meta_file, "input_address_type Z3");
+        common::write::file(&meta_path);
+        common::dggrid::execute(&self.adapter.executable, &meta_path);
+        let result = common::output::ingest(&aigen_path, &children_path, &neighbor_path, &cfg)?;
+        common::cleanup(
+            &meta_path,
+            &aigen_path,
+            &children_path,
+            &neighbor_path,
+            &bbox_path,
+            &input_path,
+        );
+        Ok(result)
+    }
+
     fn zone_from_id(
         &self,
         zone_id: ZoneId,

--- a/geoplegma/src/adapters/h3o/h3.rs
+++ b/geoplegma/src/adapters/h3o/h3.rs
@@ -117,6 +117,39 @@ impl DggrsApi for H3Impl {
 
         Ok(to_zones(h3o_sub_zones, cfg)?)
     }
+
+    fn parent_from_zone(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError> {
+        let cfg = config.unwrap_or_default();
+        let h3o_zone = CellIndex::from_str(&zone_id.to_string()).map_err(|e| {
+            DggrsError::H3o(H3oError::InvalidZoneID {
+                zone_id: zone_id.to_string(),
+                source: e,
+            })
+        })?;
+
+        let refinement_level = RefinementLevel::new(h3o_zone.resolution() as i32)?;
+        if refinement_level <= self.min_refinement_level()? {
+            return Err(DggrsError::H3o(H3oError::ResolutionLimitReached {
+                zone_id: zone_id.to_string(),
+            }));
+        }
+
+        let parent_level = RefinementLevel::new(refinement_level.get() - 1)?;
+        let parent = h3o_zone
+            .parent(refinement_level_to_h3_resolution(parent_level)?)
+            .ok_or_else(|| {
+                DggrsError::H3o(H3oError::ResolutionLimitReached {
+                    zone_id: zone_id.to_string(),
+                })
+            })?;
+
+        Ok(to_zones(vec![parent], cfg)?)
+    }
+
     fn zone_from_id(
         &self,
         zone_id: ZoneId, // ToDo: needs validation function

--- a/geoplegma/src/adapters/h3o/h3.rs
+++ b/geoplegma/src/adapters/h3o/h3.rs
@@ -118,7 +118,7 @@ impl DggrsApi for H3Impl {
         Ok(to_zones(h3o_sub_zones, cfg)?)
     }
 
-    fn parent_from_zone(
+    fn primary_parent_from_zone(
         &self,
         zone_id: ZoneId,
         config: Option<DggrsApiConfig>,

--- a/geoplegma/src/api.rs
+++ b/geoplegma/src/api.rs
@@ -75,6 +75,13 @@ pub trait DggrsApi: Send + Sync {
         config: Option<DggrsApiConfig>,
     ) -> Result<Zones, DggrsError>;
 
+    /// Get the direct parent zone for a given ZoneID.
+    fn parent_from_zone(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError>;
+
     /// Get a zone based on a ZoneID
     fn zone_from_id(
         &self,

--- a/geoplegma/src/api.rs
+++ b/geoplegma/src/api.rs
@@ -75,8 +75,10 @@ pub trait DggrsApi: Send + Sync {
         config: Option<DggrsApiConfig>,
     ) -> Result<Zones, DggrsError>;
 
-    /// Get the direct parent zone for a given ZoneID.
-    fn parent_from_zone(
+    /// Get the primary parent zone for a given ZoneID.
+    /// 
+    /// The zone returned by this function is exactly one refinement level above the input zone. Which zone gets returned as the primary parent is dependent on the DGGRS implementation.
+    fn primary_parent_from_zone(
         &self,
         zone_id: ZoneId,
         config: Option<DggrsApiConfig>,

--- a/geoplegma/tests/parent_from_zone.rs
+++ b/geoplegma/tests/parent_from_zone.rs
@@ -1,0 +1,71 @@
+use geo::Point;
+use geoplegma::adapters::dggal::grids::DggalImpl;
+use geoplegma::adapters::dggrid::igeo7::Igeo7Impl;
+use geoplegma::adapters::dggrid::isea3h::Isea3hImpl;
+use geoplegma::adapters::h3o::h3::H3Impl;
+use geoplegma::api::{DggrsApi, DggrsApiConfig};
+use geoplegma::models::common::{DggrsUid, RefinementLevel};
+
+#[test]
+fn h3_parent_from_zone_contains_child_zone() {
+    let adapter = H3Impl::default();
+    test_parent_from_zone_contains_child_zone(&adapter);
+}
+
+#[test]
+fn dggal_parent_from_zone_contains_child_zone() {
+    let adapter = DggalImpl::new(DggrsUid::ISEA3HDGGAL);
+    test_parent_from_zone_contains_child_zone(&adapter);
+}
+
+#[test]
+fn igeo7_parent_from_zone_contains_child_zone() {
+    let adapter = Igeo7Impl::default();
+    test_parent_from_zone_contains_child_zone(&adapter);
+}
+
+#[test]
+fn isea3h_parent_from_zone_contains_child_zone() {
+    let adapter = Isea3hImpl::default();
+    test_parent_from_zone_contains_child_zone(&adapter);
+}
+
+fn test_parent_from_zone_contains_child_zone<T: DggrsApi>(adapter: &T) {
+    let point = Point::new(9.06, 52.98);
+    let base_config = DggrsApiConfig {
+        area_sqm: false,
+        densify: false,
+        center: false,
+        region: false,
+        children: false,
+        neighbors: false,
+        vertex_count: false,
+    };
+    let parent_config = DggrsApiConfig {
+        children: true,
+        ..base_config
+    };
+
+    for rf in 1..15 {
+        let child_level = RefinementLevel::new(rf).unwrap();
+        let child_zone_result = adapter
+            .zone_from_point(child_level, point, Some(base_config))
+            .unwrap()
+            .zones;
+
+        let child_zone = child_zone_result.first().map(|zone| zone.id.clone()).unwrap();
+
+        let parent_zone = adapter
+            .parent_from_zone(child_zone.clone(), Some(parent_config))
+            .unwrap()
+            .zones
+            .first()
+            .unwrap()
+            .clone();
+
+        assert!(
+            parent_zone.children.unwrap().contains(&child_zone),
+            "Parent zone does not contain the queried child zone"
+        );
+    }
+}

--- a/geoplegma/tests/primary_parent_from_zone.rs
+++ b/geoplegma/tests/primary_parent_from_zone.rs
@@ -56,7 +56,7 @@ fn test_parent_from_zone_contains_child_zone<T: DggrsApi>(adapter: &T) {
         let child_zone = child_zone_result.first().map(|zone| zone.id.clone()).unwrap();
 
         let parent_zone = adapter
-            .parent_from_zone(child_zone.clone(), Some(parent_config))
+            .primary_parent_from_zone(child_zone.clone(), Some(parent_config))
             .unwrap()
             .zones
             .first()


### PR DESCRIPTION
Adds a new `primary_parent_from_zone` function to the API which returns the direct parent of a zone, one refinement level above.

- For H3: uses the `CellIndex::parent()` method
- For DGGRID: uses the operation `TRANSFORM_POINTS`
- For DGGAL: uses `DGGRS::getZoneParents()`

Steps:
- [ ] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [x] Add README documentation of what's done in the PR, if needed.
- [x] Request review
