### PR TITLE
Convert coordinates to degrees in to_point DGGAL adapter

### DIFF
--- a/geoplegma/src/adapters/dggal/common.rs
+++ b/geoplegma/src/adapters/dggal/common.rs
@@ -104,7 +104,7 @@ pub fn to_zones(
 }
 
 fn to_point(pt: &GeoPoint) -> Point<f64> {
-    Point::new(pt.lon, pt.lat)
+    Point::new(pt.lon.to_degrees(), pt.lat.to_degrees())
 }
 
 fn to_polygon(points: &[GeoPoint]) -> Polygon<f64> {


### PR DESCRIPTION
Fixes the conversion back to the geo::Point by using the `to_degrees` function, as it is already done in `to_polygon`. The inverse operation `to_geo_point` converts the coordinates to radians so this is needed for consistency.

Steps:
- [x] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [x] Add README documentation of what's done in the PR, if needed.
- [x] Request review
