### PR TITLE
Add serde feature

### DIFF
--- a/geoplegma/Cargo.toml
+++ b/geoplegma/Cargo.toml
@@ -25,6 +25,10 @@ rayon = "1.10.0"
 thiserror = "2.0.12"
 once_cell = "1.21.0"
 itertools = "0.14.0"
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/geoplegma/src/types.rs
+++ b/geoplegma/src/types.rs
@@ -82,6 +82,7 @@ impl BoundingBox {
 
 // NOTE: The naming needs to be adjusted to the DGGRS Registry
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DggrsUid {
     ISEA3HDGGRID,
     IGEO7,

--- a/gp-encoding/Cargo.toml
+++ b/gp-encoding/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../README.md"
 rust-version = "1.88"
 
 [dependencies]
-geoplegma = { path = "../geoplegma" }
+geoplegma = { path = "../geoplegma", features = ["serde"] }
 gdal = "0.19"
 geo = "0.30"
 rayon = "1.11"

--- a/gp-encoding/src/models.rs
+++ b/gp-encoding/src/models.rs
@@ -11,27 +11,9 @@ use clap::ValueEnum;
 use geoplegma::types::DggrsUid;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
-#[allow(non_camel_case_types)]
-#[serde(remote = "DggrsUid")]
-pub enum DggrsUidDef {
-    ISEA3HDGGRID,
-    IGEO7,
-    H3,
-    IVEA3H,
-    ISEA3HDGGAL,
-    IVEA9R,
-    ISEA9R,
-    RTEA3H,
-    RTEA9R,
-    IVEA7H,
-    IVEA7H_Z7,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatasetMetadata {
     /// DGGS Reference System identifier
-    #[serde(with = "DggrsUidDef")]
     pub dggrs: DggrsUid,
 
     /// Schema of the stored attributes.


### PR DESCRIPTION
Implements Option 1 of #124 by adding serde as an optional dependency for geoplegma, which can be enabled by feature. I've only added the `Serialize`/`Deserialize` derives to `DggrsUid`. Other relevant structs could also have this in the future.

Closes #124

Steps:
- [x] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [x] Add README documentation of what's done in the PR, if needed.
- [x] Request review
