### PR TITLE
Expanded convert functionality in gp-encoding

### DIFF
--- a/gp-encoding/README.md
+++ b/gp-encoding/README.md
@@ -31,7 +31,7 @@ cargo run -p gp-encoding -- --help
 Here is an example of how to use the CLI utility to convert a GeoTIFF file, create a pyramid, and query some statistics about the raster:
 
 ```bash
-cargo run -p gp-encoding -- convert-geotiff --input input.tif --output output.zarr --dggrs H3 --report
+cargo run -p gp-encoding -- convert --input input.tif --output output.zarr --dggrs H3 --report
 cargo run -p gp-encoding -- add-level --store output.zarr --target-level 5
 cargo run -p gp-encoding -- stats --store output.zarr
 ```

--- a/gp-encoding/src/convert.rs
+++ b/gp-encoding/src/convert.rs
@@ -13,7 +13,7 @@ use std::str::FromStr;
 
 use gdal::raster::GdalDataType;
 use gdal::spatial_ref::{CoordTransform, SpatialRef};
-use gdal::{Dataset, GeoTransformEx};
+use gdal::{Dataset, GeoTransformEx, Metadata};
 use geoplegma::api::DggrsApiConfig;
 use geoplegma::get;
 use geoplegma::types::{BoundingBox, DggrsUid, Point, RefinementLevel, RelativeDepth, ZoneId};
@@ -122,7 +122,7 @@ fn nearest_pixel_coord_for_center(
     height: usize,
 ) -> Result<Option<(usize, usize)>, EncodingError> {
     if width == 0 || height == 0 {
-        return Err(EncodingError::GeoTiff(
+        return Err(EncodingError::Dataset(
             "raster has zero width or height".into(),
         ));
     }
@@ -134,7 +134,7 @@ fn nearest_pixel_coord_for_center(
 
     let det = gt[1] * gt[5] - gt[2] * gt[4];
     if det.abs() < f64::EPSILON {
-        return Err(EncodingError::GeoTiff(
+        return Err(EncodingError::Dataset(
             "geotransform is not invertible".into(),
         ));
     }
@@ -164,7 +164,7 @@ fn get_closest_refinement_level(
     pixel_height: f64,
 ) -> Result<RefinementLevel, EncodingError> {
     if pixel_width == 0.0 || pixel_height == 0.0 {
-        return Err(EncodingError::GeoTiff(
+        return Err(EncodingError::Dataset(
             "geotransform has zero pixel size".into(),
         ));
     }
@@ -311,8 +311,46 @@ pub fn compute_source_report(dataset: &Dataset) -> Result<SourceRasterReport, En
     })
 }
 
-pub fn convert_geotiff_file_to_backend<B>(
-    geotiff_path: &Path,
+pub fn list_subdatasets(dataset: &Dataset) -> Vec<(String, String)> {
+    let mut subdatasets = Vec::new();
+    if let Some(domain) = dataset.metadata_domain("SUBDATASETS") {
+        let mut name_map = std::collections::BTreeMap::new();
+        let mut desc_map = std::collections::BTreeMap::new();
+        for item in domain {
+            if let Some((key, value)) = item.split_once('=') {
+                if key.starts_with("SUBDATASET_") {
+                    if key.ends_with("_NAME") {
+                        if let Some(num_str) = key.strip_prefix("SUBDATASET_").and_then(|k| k.strip_suffix("_NAME")) {
+                            if let Ok(num) = num_str.parse::<usize>() {
+                                name_map.insert(num, value.to_string());
+                            }
+                        }
+                    } else if key.ends_with("_DESC") {
+                        if let Some(num_str) = key.strip_prefix("SUBDATASET_").and_then(|k| k.strip_suffix("_DESC")) {
+                            if let Ok(num) = num_str.parse::<usize>() {
+                                desc_map.insert(num, value.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        for (num, name) in name_map {
+            let desc = desc_map.get(&num).cloned().unwrap_or_default();
+            subdatasets.push((name, desc));
+        }
+    }
+    subdatasets
+}
+
+pub fn get_subdataset_short_name(name: &str) -> String {
+    let last_part = name.split(':').last().unwrap_or(name);
+    last_part.trim_matches(|c| c == '/' || c == '"' || c == '\'' || c == ' ').to_string()
+}
+
+pub fn convert_to_backend<B>(
+    input_str: &str,
+    subdataset: Option<&str>,
     output_path: &Path,
     dggrs: DggrsUid,
     compression: Option<Compression>,
@@ -320,21 +358,62 @@ pub fn convert_geotiff_file_to_backend<B>(
 where
     B: StorageBackend,
 {
-    if !geotiff_path.exists() {
-        return Err(EncodingError::GeoTiff(format!(
-            "input GeoTIFF does not exist: {}",
-            geotiff_path.display()
-        )));
-    }
-    if !geotiff_path.is_file() {
-        return Err(EncodingError::GeoTiff(format!(
-            "input GeoTIFF is not a file: {}",
-            geotiff_path.display()
-        )));
-    }
     let grid = get(dggrs)?;
 
-    let dataset = Dataset::open(geotiff_path)?;
+    let initial_dataset = Dataset::open(input_str).map_err(|e| {
+        EncodingError::Dataset(format!(
+            "failed to open input dataset '{}': {e}",
+            input_str
+        ))
+    })?;
+
+    let subdatasets = list_subdatasets(&initial_dataset);
+    let (dataset, open_str) = if !subdatasets.is_empty() {
+        if let Some(sub) = subdataset {
+            let matched = subdatasets.iter().find(|(name, _)| {
+                let short_name = get_subdataset_short_name(name);
+                short_name.eq_ignore_ascii_case(sub) || name.to_lowercase().contains(&sub.to_lowercase())
+            });
+            if let Some((name, _)) = matched {
+                let ds = Dataset::open(name).map_err(|e| {
+                    EncodingError::Dataset(format!(
+                        "failed to open subdataset '{}': {e}",
+                        name
+                    ))
+                })?;
+                (ds, name.clone())
+            } else {
+                let mut msg = format!(
+                    "Subdataset '{}' not found in input. Available subdatasets:\n",
+                    sub
+                );
+                for (name, desc) in &subdatasets {
+                    let short_name = get_subdataset_short_name(name);
+                    msg.push_str(&format!("  - {} ({})\n", short_name, desc));
+                }
+                return Err(EncodingError::Dataset(msg));
+            }
+        } else {
+            let mut msg = format!(
+                "Input dataset '{}' contains multiple subdatasets. Please specify one using --subdataset <name>.\nAvailable subdatasets:\n",
+                input_str
+            );
+            for (name, desc) in &subdatasets {
+                let short_name = get_subdataset_short_name(name);
+                msg.push_str(&format!("  - {} ({})\n", short_name, desc));
+            }
+            return Err(EncodingError::Dataset(msg));
+        }
+    } else {
+        if let Some(sub) = subdataset {
+            return Err(EncodingError::Dataset(format!(
+                "Input dataset does not contain subdatasets, but --subdataset '{}' was specified.",
+                sub
+            )));
+        }
+        (initial_dataset, input_str.to_string())
+    };
+
     let source_report = compute_source_report(&dataset)?;
 
     let bands = dataset
@@ -356,7 +435,7 @@ where
                 GdalDataType::Float32 => DataType::Float32,
                 GdalDataType::Float64 => DataType::Float64,
                 _ => {
-                    return Err(EncodingError::GeoTiff(format!(
+                    return Err(EncodingError::Dataset(format!(
                         "unsupported GDAL data type: {band_type:?}"
                     )));
                 }
@@ -378,7 +457,7 @@ where
     let (width, height) = dataset.raster_size();
 
     if width == 0 || height == 0 {
-        return Err(EncodingError::GeoTiff(
+        return Err(EncodingError::Dataset(
             "raster has zero width or height".into(),
         ));
     }
@@ -486,7 +565,7 @@ where
 
     let progress_counter = std::sync::atomic::AtomicU64::new(0);
 
-    let geotiff_path_buf = geotiff_path.to_path_buf();
+    let open_str_clone = open_str.clone();
 
     let results: Vec<Vec<BandStatsCollector>> = chunk_zones
         .zones
@@ -503,14 +582,14 @@ where
                     gdal::spatial_ref::AxisMappingStrategy::TraditionalGisOrder,
                 );
                 let transform = CoordTransform::new(&wgs84, &src_srs)?;
-                let thread_dataset = Dataset::open(&geotiff_path_buf)?;
+                let thread_dataset = Dataset::open(&open_str_clone)?;
                 Ok((transform, thread_dataset))
             },
             |state, (chunk_index, chunk_zone)| {
                 let (wgs84_to_src, thread_dataset) = match state {
                     Ok(s) => s,
                     Err(e) => {
-                        return Err(EncodingError::GeoTiff(format!(
+                        return Err(EncodingError::Dataset(format!(
                             "failed to initialize thread-local transform/dataset: {e}"
                         )));
                     }
@@ -629,7 +708,7 @@ where
                             GdalDataType::Int64 => process_window!(i64),
                             GdalDataType::Float32 => process_window!(f32),
                             GdalDataType::Float64 => process_window!(f64),
-                            _ => return Err(EncodingError::GeoTiff(format!(
+                            _ => return Err(EncodingError::Dataset(format!(
                                 "unsupported GDAL data type: {band_type:?}"
                             ))),
                         }
@@ -1141,6 +1220,15 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&src_store_path);
         let _ = std::fs::remove_dir_all(&tgt_store_path);
+    }
+
+    #[test]
+    fn test_get_subdataset_short_name() {
+        assert_eq!(get_subdataset_short_name("NETCDF:\"file.nc\":elevation"), "elevation");
+        assert_eq!(get_subdataset_short_name("HDF5:\"file.h5\"://elevation"), "elevation");
+        assert_eq!(get_subdataset_short_name("NETCDF:\"/path/to/file.nc\":temp"), "temp");
+        assert_eq!(get_subdataset_short_name("simple_name"), "simple_name");
+        assert_eq!(get_subdataset_short_name("HDF5:file.h5:variable_with_spaces "), "variable_with_spaces");
     }
 }
 

--- a/gp-encoding/src/convert.rs
+++ b/gp-encoding/src/convert.rs
@@ -60,7 +60,11 @@ fn get_corners_and_pixel_size(
     let h = height_px as f64;
 
     let gt = dataset.geo_transform()?;
-    let src_srs = dataset.spatial_ref()?;
+    let src_srs = dataset.spatial_ref().unwrap_or_else(|_| {
+        let mut srs = SpatialRef::from_epsg(4326).unwrap();
+        srs.set_axis_mapping_strategy(gdal::spatial_ref::AxisMappingStrategy::TraditionalGisOrder);
+        srs
+    });
 
     let mut wgs84 = SpatialRef::from_epsg(4326)?;
     wgs84.set_axis_mapping_strategy(gdal::spatial_ref::AxisMappingStrategy::TraditionalGisOrder);
@@ -372,7 +376,7 @@ where
         if let Some(sub) = subdataset {
             let matched = subdatasets.iter().find(|(name, _)| {
                 let short_name = get_subdataset_short_name(name);
-                short_name.eq_ignore_ascii_case(sub) || name.to_lowercase().contains(&sub.to_lowercase())
+                short_name.eq_ignore_ascii_case(sub) || short_name.to_lowercase().contains(&sub.to_lowercase())
             });
             if let Some((name, _)) = matched {
                 let ds = Dataset::open(name).map_err(|e| {
@@ -463,7 +467,11 @@ where
     }
 
     let gt = dataset.geo_transform()?;
-    let src_srs = dataset.spatial_ref()?;
+    let src_srs = dataset.spatial_ref().unwrap_or_else(|_| {
+        let mut srs = SpatialRef::from_epsg(4326).unwrap();
+        srs.set_axis_mapping_strategy(gdal::spatial_ref::AxisMappingStrategy::TraditionalGisOrder);
+        srs
+    });
     let (bbox, pixel_width, pixel_height) = get_corners_and_pixel_size(&dataset)?;
     let refinement_level = get_closest_refinement_level(&grid, pixel_width, pixel_height)?;
 

--- a/gp-encoding/src/error.rs
+++ b/gp-encoding/src/error.rs
@@ -23,8 +23,8 @@ pub enum EncodingError {
     #[error("DGGRS Fabric error: {0}")]
     DggrsFabric(#[from] geoplegma::error::factory::FactoryError),
 
-    #[error("GeoTIFF error: {0}")]
-    GeoTiff(String),
+    #[error("Dataset error: {0}")]
+    Dataset(String),
 
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),

--- a/gp-encoding/src/geotiff_convert.rs
+++ b/gp-encoding/src/geotiff_convert.rs
@@ -7,19 +7,21 @@
 // discretion. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::str::FromStr;
 
 use gdal::raster::GdalDataType;
 use gdal::spatial_ref::{CoordTransform, SpatialRef};
 use gdal::{Dataset, GeoTransformEx};
 use geoplegma::api::DggrsApiConfig;
 use geoplegma::get;
-use geoplegma::types::{BoundingBox, DggrsUid, Point, RefinementLevel, RelativeDepth};
+use geoplegma::types::{BoundingBox, DggrsUid, Point, RefinementLevel, RelativeDepth, ZoneId};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
 
 use crate::AttributeSchema;
-use crate::common::CONFIG;
+use crate::common::{CONFIG, ID_ONLY_CONFIG};
 use crate::error::EncodingError;
 use crate::models::{Compression, DataType, DatasetMetadata};
 use crate::stats::{BandStatsCollector, ConversionReport, SourceRasterReport};
@@ -671,3 +673,475 @@ where
 
     Ok((backend, source_report, report))
 }
+
+pub fn convert_dggrs_store_to_backend<B>(
+    source_store_path: &Path,
+    output_path: &Path,
+    target_dggrs: DggrsUid,
+    compression: Option<Compression>,
+) -> Result<B, EncodingError>
+where
+    B: StorageBackend,
+{
+    let source_backend = B::open(source_store_path)?;
+    let source_metadata = source_backend.metadata();
+    let source_dggrs = source_metadata.dggrs;
+
+    let source_grid = get(source_dggrs)
+        .map_err(|e| EncodingError::Grid(format!("failed to resolve source DGGS: {e}")))?;
+    let target_grid = get(target_dggrs)
+        .map_err(|e| EncodingError::Grid(format!("failed to resolve target DGGS: {e}")))?;
+
+    let source_levels = source_backend.levels();
+    if source_levels.is_empty() {
+        return Err(EncodingError::Storage("source store has no resolution levels".into()));
+    }
+
+    let mut level_mapping = Vec::new();
+    let mut target_levels = Vec::new();
+
+    for &src_lvl in &source_levels {
+        let src_ref_lvl = RefinementLevel::new(src_lvl as i32)?;
+        let src_count = source_grid.zone_count(src_ref_lvl)?;
+
+        let mut best_level = target_grid.min_refinement_level()?;
+        let mut best_diff = u64::MAX;
+        for l in target_grid.min_refinement_level()?.get()..=target_grid.max_refinement_level()?.get() {
+            let level = RefinementLevel::new(l)?;
+            let count = target_grid.zone_count(level)?;
+            let diff = src_count.abs_diff(count);
+            if diff < best_diff {
+                best_diff = diff;
+                best_level = level;
+            }
+        }
+        let tgt_lvl = best_level.get() as u32;
+        level_mapping.push((src_lvl, tgt_lvl));
+        target_levels.push(tgt_lvl);
+    }
+
+    target_levels.sort_unstable();
+    target_levels.dedup();
+
+    println!("Mapping levels from {} to {}:", source_dggrs, target_dggrs);
+    for &(src, tgt) in &level_mapping {
+        println!("  Source Level {} -> Target Level {}", src, tgt);
+    }
+
+    let max_target_level_u32 = target_levels.iter().max().copied().unwrap_or(0);
+    let max_target_level = RefinementLevel::new(max_target_level_u32 as i32)?;
+
+    let data_type_size_bytes = source_metadata.attributes
+        .iter()
+        .map(|band| band.dtype.byte_size())
+        .max()
+        .ok_or_else(|| {
+            EncodingError::Storage("dataset metadata must define at least one attribute".into())
+        })?;
+
+    let target_min_chunk_level = target_grid.min_refinement_level()?;
+    let target_max_relative_depth_allowed = target_grid.max_relative_depth()?;
+
+    let (_best_chunk_level, chunk_size) = choose_best_chunk_level_and_size(
+        max_target_level,
+        target_min_chunk_level,
+        target_max_relative_depth_allowed,
+        target_dggrs.spec().aperture as u64,
+        data_type_size_bytes,
+    )?;
+
+    let target_compression = compression.or_else(|| source_metadata.compression.clone());
+
+    let target_metadata = DatasetMetadata {
+        dggrs: target_dggrs,
+        attributes: source_metadata.attributes.clone(),
+        chunk_size,
+        levels: target_levels.clone(),
+        compression: target_compression,
+    };
+
+    let mut target_backend = B::create(output_path, target_metadata)?;
+
+    for &(source_level, target_level) in &level_mapping {
+        println!("\nConverting Level {source_level} -> {target_level}...");
+
+        let (source_chunk_level_u32, source_chunk_ids) = source_backend.chunk_ids_for_level(source_level)?;
+        if source_chunk_ids.is_empty() {
+            println!("  Warning: source level {source_level} has no chunk IDs, skipping.");
+            continue;
+        }
+
+        let mut min_lon = f64::INFINITY;
+        let mut max_lon = f64::NEG_INFINITY;
+        let mut min_lat = f64::INFINITY;
+        let mut max_lat = f64::NEG_INFINITY;
+        let mut has_any = false;
+
+        for chunk_id_str in &source_chunk_ids {
+            let chunk_zone_id = ZoneId::from_str(chunk_id_str)?;
+            let zones = source_grid.zone_from_id(chunk_zone_id, Some(DggrsApiConfig {
+                region: true,
+                center: false,
+                vertex_count: false,
+                children: false,
+                neighbors: false,
+                area_sqm: false,
+                densify: false,
+            }))?;
+            if let Some(zone) = zones.zones.first() {
+                if let Some(region) = &zone.region {
+                    for pt in &region.exterior {
+                        min_lon = min_lon.min(pt.lon);
+                        max_lon = max_lon.max(pt.lon);
+                        min_lat = min_lat.min(pt.lat);
+                        max_lat = max_lat.max(pt.lat);
+                        has_any = true;
+                    }
+                }
+            }
+        }
+
+        let bbox = if has_any {
+            let lon_padding = (max_lon - min_lon) * 0.01;
+            let lat_padding = (max_lat - min_lat) * 0.01;
+            let min_lon = (min_lon - lon_padding).max(-180.0);
+            let max_lon = (max_lon + lon_padding).min(180.0);
+            let min_lat = (min_lat - lat_padding).max(-90.0);
+            let max_lat = (max_lat + lat_padding).min(90.0);
+
+            let tolerance = 1e-4;
+            let is_global = (min_lon <= -180.0 + tolerance)
+                && (max_lon >= 180.0 - tolerance)
+                && (min_lat <= -90.0 + tolerance)
+                && (max_lat >= 90.0 - tolerance);
+            if is_global {
+                None
+            } else {
+                Some(BoundingBox::new(min_lon, min_lat, max_lon, max_lat))
+            }
+        } else {
+            None
+        };
+
+        let (target_chunk_level, target_level_chunk_size) = choose_best_chunk_level_and_size(
+            RefinementLevel::new(target_level as i32)?,
+            target_min_chunk_level,
+            target_max_relative_depth_allowed,
+            target_dggrs.spec().aperture as u64,
+            data_type_size_bytes,
+        )?;
+
+        let target_chunk_zones = target_grid.zones_from_bbox(target_chunk_level, bbox, Some(CONFIG))?;
+        if target_chunk_zones.zones.is_empty() {
+            return Err(EncodingError::Grid(
+                "no target zones found intersecting bounding box".into(),
+            ));
+        }
+        let target_chunk_ids: Vec<String> = target_chunk_zones
+            .zones
+            .iter()
+            .map(|z| z.id.to_string())
+            .collect();
+
+        target_backend.set_level_chunk_ids(
+            target_level,
+            target_chunk_level.get() as u32,
+            target_chunk_ids.clone(),
+        )?;
+
+        let encoded_num_cells = (target_chunk_ids.len() as u64)
+            .checked_mul(target_level_chunk_size)
+            .ok_or_else(|| EncodingError::Storage("encoded cell count overflow".into()))?;
+
+        let band_count = source_backend.band_count();
+        for band_idx in 0..band_count {
+            target_backend.create_level(
+                target_level,
+                band_idx,
+                encoded_num_cells,
+                target_level_chunk_size,
+            )?;
+        }
+
+        let source_chunk_level = RefinementLevel::new(source_chunk_level_u32 as i32)?;
+        let source_relative_depth = RelativeDepth::new(source_level as i32 - source_chunk_level.get())?;
+
+        println!("  Building source cell lookup index...");
+        let mut source_cell_to_index = HashMap::new();
+        for (chunk_idx, chunk_id_str) in source_chunk_ids.iter().enumerate() {
+            let chunk_zone_id = ZoneId::from_str(chunk_id_str)?;
+            let children = source_grid.zones_from_parent(
+                source_relative_depth,
+                chunk_zone_id,
+                Some(ID_ONLY_CONFIG),
+            )?;
+            for (in_chunk_idx, child) in children.zones.iter().enumerate() {
+                source_cell_to_index.insert(child.id.clone(), (chunk_idx, in_chunk_idx));
+            }
+        }
+        let fill_value_bytes: Vec<Vec<u8>> = target_backend
+            .metadata()
+            .attributes
+            .iter()
+            .map(|attr| {
+                let fill_val = match &attr.fill_value {
+                    Some(value) => parse_fill_value_to_f64(&attr.dtype, value)?,
+                    None => 0.0,
+                };
+                encode_value_from_f64(&attr.dtype, fill_val)
+            })
+            .collect::<Result<_, EncodingError>>()?;
+
+        let total_target_chunks = target_chunk_ids.len();
+        let chunk_progress = ProgressBar::new(total_target_chunks as u64);
+        let style = ProgressStyle::with_template(
+            "  Resampling chunks [{bar:40.cyan/blue}] {pos}/{len} ({percent}%)",
+        )
+        .map_err(|e| EncodingError::Storage(format!("invalid progress bar template: {e}")))?
+        .progress_chars("=> ");
+        chunk_progress.set_style(style);
+
+        let progress_counter = std::sync::atomic::AtomicU64::new(0);
+        let target_relative_depth = RelativeDepth::new(target_level as i32 - target_chunk_level.get())?;
+        let center_config = DggrsApiConfig {
+            center: true,
+            ..CONFIG
+        };
+
+        target_chunk_ids
+            .par_iter()
+            .enumerate()
+            .try_for_each(|(target_chunk_idx, target_chunk_id_str)| -> Result<(), EncodingError> {
+                let target_chunk_zone_id = ZoneId::from_str(target_chunk_id_str)?;
+                let children = target_grid.zones_from_parent(
+                    target_relative_depth,
+                    target_chunk_zone_id,
+                    Some(center_config),
+                )?;
+
+                if children.zones.len() > target_level_chunk_size as usize {
+                    return Err(EncodingError::Grid(format!(
+                        "target chunk {target_chunk_id_str} has {} children but chunk_size is {target_level_chunk_size}",
+                        children.zones.len()
+                    )));
+                }
+
+                let mut band_chunk_bytes: Vec<Vec<u8>> = (0..band_count)
+                    .map(|band_idx| {
+                        let dtype = &target_backend.metadata().attributes[band_idx as usize].dtype;
+                        let val_size = dtype.byte_size();
+                        let fill_bytes = &fill_value_bytes[band_idx as usize];
+                        let mut chunk_bytes = vec![0_u8; target_level_chunk_size as usize * val_size];
+                        for cell_idx in 0..target_level_chunk_size as usize {
+                            let start = cell_idx * val_size;
+                            let end = start + val_size;
+                            chunk_bytes[start..end].copy_from_slice(fill_bytes);
+                        }
+                        chunk_bytes
+                    })
+                    .collect();
+
+                let source_refinement_level = RefinementLevel::new(source_level as i32)?;
+
+                let mut required_src_chunks = HashSet::new();
+                for target_cell in &children.zones {
+                    let center = target_cell.center.ok_or_else(|| {
+                        EncodingError::Grid(format!(
+                            "target zone {} has no center coordinates",
+                            target_cell.id
+                        ))
+                    })?;
+
+                    let source_zones = source_grid.zone_from_point(
+                        source_refinement_level,
+                        center,
+                        Some(ID_ONLY_CONFIG),
+                    )?;
+
+                    if let Some(source_zone) = source_zones.zones.first() {
+                        if let Some(&(src_chunk_idx, _)) = source_cell_to_index.get(&source_zone.id) {
+                            required_src_chunks.insert(src_chunk_idx);
+                        }
+                    }
+                }
+
+                let mut local_src_chunks = HashMap::with_capacity(required_src_chunks.len());
+                for &src_chunk_idx in &required_src_chunks {
+                    let mut bands_data = Vec::with_capacity(band_count as usize);
+                    for band_idx in 0..band_count {
+                        let chunk = source_backend.read_chunk(source_level, band_idx, src_chunk_idx as u64)?;
+                        bands_data.push(chunk);
+                    }
+                    local_src_chunks.insert(src_chunk_idx, bands_data);
+                }
+
+                for (in_chunk_idx, target_cell) in children.zones.iter().enumerate() {
+                    let center = target_cell.center.ok_or_else(|| {
+                        EncodingError::Grid(format!(
+                            "target zone {} has no center coordinates",
+                            target_cell.id
+                        ))
+                    })?;
+
+                    let source_zones = source_grid.zone_from_point(
+                        source_refinement_level,
+                        center,
+                        Some(ID_ONLY_CONFIG),
+                    )?;
+
+                    if let Some(source_zone) = source_zones.zones.first() {
+                        if let Some(&(src_chunk_idx, src_in_chunk_idx)) = source_cell_to_index.get(&source_zone.id) {
+                            if let Some(bands_data) = local_src_chunks.get(&src_chunk_idx) {
+                                for band_idx in 0..band_count {
+                                    let dtype = &target_backend.metadata().attributes[band_idx as usize].dtype;
+                                    let val_size = dtype.byte_size();
+                                    let src_chunk = &bands_data[band_idx as usize];
+
+                                    let src_start = src_in_chunk_idx * val_size;
+                                    let src_end = src_start + val_size;
+                                    if src_chunk.len() < src_end {
+                                        return Err(EncodingError::Storage(format!(
+                                            "source chunk {src_chunk_idx} is too small"
+                                        )));
+                                    }
+
+                                    let target_start = in_chunk_idx * val_size;
+                                    let target_end = target_start + val_size;
+                                    band_chunk_bytes[band_idx as usize][target_start..target_end]
+                                        .copy_from_slice(&src_chunk[src_start..src_end]);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                for band_idx in 0..band_count {
+                    target_backend.write_chunk(
+                        target_level,
+                        band_idx,
+                        target_chunk_idx as u64,
+                        &band_chunk_bytes[band_idx as usize],
+                    )?;
+                }
+
+                let done = progress_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+                chunk_progress.set_position(done);
+
+                Ok(())
+            })?;
+
+        chunk_progress.finish_with_message("  Resampling complete");
+    }
+
+    Ok(target_backend)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::path::PathBuf;
+    use crate::zarr::ZarrBackend;
+    use crate::query::query_value_for_point;
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("gp_encoding_{name}_{nanos}"))
+    }
+
+    #[test]
+    fn test_convert_dggrs_store_to_backend_resamples_correctly() {
+        let src_store_path = unique_temp_dir("dggrs_convert_src");
+        let tgt_store_path = unique_temp_dir("dggrs_convert_tgt");
+
+        // 1. Create a source Zarr store (H3)
+        let dggrs_src = DggrsUid::H3;
+        let grid_src = get(dggrs_src).expect("resolve src dggrs");
+        let src_refinement_level = RefinementLevel::new(1).expect("src refinement level");
+        let src_chunk_level = RefinementLevel::new(0).expect("src chunk level");
+        let src_chunk_size = u64::from(dggrs_src.spec().aperture);
+
+        let src_chunk_zones = grid_src
+            .zones_from_bbox(src_chunk_level, None, Some(ID_ONLY_CONFIG))
+            .expect("src chunk zones");
+        assert!(!src_chunk_zones.zones.is_empty(), "expected source chunk zones");
+
+        let src_chunk0_id = src_chunk_zones.zones[0].id.clone();
+        
+        let mut child_config = ID_ONLY_CONFIG;
+        child_config.center = true;
+        
+        let src_children = grid_src
+            .zones_from_parent(RelativeDepth::new_const(1), src_chunk0_id.clone(), Some(child_config))
+            .expect("src children");
+        assert!(!src_children.zones.is_empty(), "expected source children");
+
+        let src_metadata = DatasetMetadata {
+            dggrs: dggrs_src,
+            attributes: vec![AttributeSchema {
+                dtype: DataType::Float32,
+                fill_value: Some("0.0".to_string()),
+            }],
+            chunk_size: src_chunk_size,
+            levels: vec![src_refinement_level.get() as u32],
+            compression: None,
+        };
+
+        let mut src_backend = ZarrBackend::create(&src_store_path, src_metadata).expect("create src zarr");
+        src_backend
+            .set_level_chunk_ids(
+                src_refinement_level.get() as u32,
+                src_chunk_level.get() as u32,
+                vec![src_chunk0_id.to_string()],
+            )
+            .expect("set src chunk ids");
+        src_backend
+            .create_level(src_refinement_level.get() as u32, 0, src_chunk_size, src_chunk_size)
+            .expect("create src level");
+
+        let chunk_values = vec![42.0_f32; src_chunk_size as usize];
+        let chunk_bytes: Vec<u8> = chunk_values
+            .into_iter()
+            .flat_map(f32::to_ne_bytes)
+            .collect();
+        src_backend
+            .write_chunk(src_refinement_level.get() as u32, 0, 0, &chunk_bytes)
+            .expect("write src chunk");
+
+        // Use the center point of one child cell
+        let target_center_pt = src_children.zones[0].center.expect("expected center point");
+
+        // 2. Convert from H3 to IVEA3H
+        let dggrs_tgt = DggrsUid::IVEA3H;
+        let tgt_backend: ZarrBackend = convert_dggrs_store_to_backend(
+            &src_store_path,
+            &tgt_store_path,
+            dggrs_tgt,
+            None,
+        )
+        .expect("convert dggrs store");
+
+        assert_eq!(tgt_backend.metadata().dggrs, dggrs_tgt);
+        assert_eq!(tgt_backend.metadata().attributes.len(), 1);
+        assert_eq!(tgt_backend.metadata().attributes[0].dtype, DataType::Float32);
+
+        // 3. Query a point in the target backend to see if it resampled correctly
+        let tgt_levels = tgt_backend.levels();
+        assert!(!tgt_levels.is_empty(), "target levels should not be empty");
+        let tgt_level = RefinementLevel::new(tgt_levels[0] as i32).expect("tgt level");
+
+        let res_bytes = query_value_for_point(&tgt_backend, tgt_level, 0, target_center_pt)
+            .expect("query value on target store");
+        let value = f32::from_ne_bytes([res_bytes[0], res_bytes[1], res_bytes[2], res_bytes[3]]);
+        
+        assert_eq!(value, 42.0);
+
+        let _ = std::fs::remove_dir_all(&src_store_path);
+        let _ = std::fs::remove_dir_all(&tgt_store_path);
+    }
+}
+
+

--- a/gp-encoding/src/lib.rs
+++ b/gp-encoding/src/lib.rs
@@ -20,7 +20,7 @@ pub mod zarr;
 pub use geoplegma::api::DggrsApi;
 pub use geoplegma::types::{BoundingBox, RefinementLevel, RelativeDepth, Zone, ZoneId, Zones};
 
-pub use geotiff_convert::{compute_source_report, convert_geotiff_file_to_backend};
+pub use geotiff_convert::{compute_source_report, convert_geotiff_file_to_backend, convert_dggrs_store_to_backend};
 pub use models::{AttributeSchema, Compression, DataType, DatasetMetadata};
 pub use query::{
     VisualizationCell, export_level_as_visualization_json, query_value_by_cell_index,

--- a/gp-encoding/src/lib.rs
+++ b/gp-encoding/src/lib.rs
@@ -9,7 +9,7 @@
 
 mod common;
 pub mod error;
-pub mod geotiff_convert;
+pub mod convert;
 pub mod models;
 pub mod query;
 pub mod stats;
@@ -20,7 +20,7 @@ pub mod zarr;
 pub use geoplegma::api::DggrsApi;
 pub use geoplegma::types::{BoundingBox, RefinementLevel, RelativeDepth, Zone, ZoneId, Zones};
 
-pub use geotiff_convert::{compute_source_report, convert_geotiff_file_to_backend, convert_dggrs_store_to_backend};
+pub use convert::{compute_source_report, convert_to_backend, convert_dggrs_store_to_backend};
 pub use models::{AttributeSchema, Compression, DataType, DatasetMetadata};
 pub use query::{
     VisualizationCell, export_level_as_visualization_json, query_value_by_cell_index,

--- a/gp-encoding/src/main.rs
+++ b/gp-encoding/src/main.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 use clap::{Args, Parser, Subcommand};
 use geoplegma::types::{DggrsUid, Point, RefinementLevel};
 use gp_encoding::{
-    Compression, StorageBackend, ZarrBackend, convert_geotiff_file_to_backend, format_value,
-    query_value_for_point,
+    Compression, StorageBackend, ZarrBackend, convert_dggrs_store_to_backend,
+    convert_geotiff_file_to_backend, format_value, query_value_for_point,
 };
 
 #[derive(Parser, Debug)]
@@ -29,8 +29,8 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Convert a GeoTIFF file into a Zarr-backed encoded dataset.
-    ConvertGeotiff(ConvertGeotiffArgs),
+    /// Convert a GeoTIFF file or existing DGGRS Zarr store into a Zarr-backed encoded dataset.
+    Convert(ConvertArgs),
     /// Add a coarser resolution level by aggregating an existing level.
     AddLevel(AddLevelArgs),
     /// Query a value at geographic coordinates.
@@ -40,15 +40,15 @@ enum Commands {
 }
 
 #[derive(Args, Debug)]
-struct ConvertGeotiffArgs {
+struct ConvertArgs {
     /// DGGRS to use for the output dataset.
     #[arg(short, long)]
     dggrs: DggrsUid,
-    /// Input GeoTIFF path.
+    /// Input GeoTIFF path or existing Zarr store directory path.
     #[arg(short, long)]
     input: PathBuf,
     /// Output Zarr store path.
-    #[arg(short, long, default_value = "./tmp/gp_encoding_geotiff_convert")]
+    #[arg(short, long, default_value = "./tmp/gp_encoding_convert")]
     output: PathBuf,
     /// Optional compression for Zarr chunks.
     #[arg(long, value_enum)]
@@ -101,7 +101,7 @@ fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Commands::ConvertGeotiff(args) => run_convert_geotiff(args),
+        Commands::Convert(args) => run_convert(args),
         Commands::AddLevel(args) => run_add_level(args),
         Commands::Query(args) => run_query(args),
         Commands::Stats(args) => run_stats(args),
@@ -113,7 +113,7 @@ fn main() {
     }
 }
 
-fn run_convert_geotiff(args: ConvertGeotiffArgs) -> Result<(), String> {
+fn run_convert(args: ConvertArgs) -> Result<(), String> {
     if args.output.exists() {
         std::fs::remove_dir_all(&args.output).map_err(|e| {
             format!(
@@ -123,8 +123,27 @@ fn run_convert_geotiff(args: ConvertGeotiffArgs) -> Result<(), String> {
         })?;
     }
 
-    let (backend, source_report, conversion_report) =
-        convert_geotiff_file_to_backend::<ZarrBackend>(
+    if args.input.is_file() {
+        let (backend, source_report, conversion_report) =
+            convert_geotiff_file_to_backend::<ZarrBackend>(
+                &args.input,
+                &args.output,
+                args.dggrs,
+                args.compression,
+            )
+            .map_err(|e| e.to_string())?;
+
+        println!("Conversion successful");
+        println!("  Input (GeoTIFF): {}", args.input.display());
+        println!("  Output:          {}", args.output.display());
+        println!("  Levels:          {:?}", backend.levels());
+
+        if args.report {
+            print!("{source_report}");
+            print!("{conversion_report}");
+        }
+    } else if args.input.is_dir() {
+        let backend = convert_dggrs_store_to_backend::<ZarrBackend>(
             &args.input,
             &args.output,
             args.dggrs,
@@ -132,14 +151,15 @@ fn run_convert_geotiff(args: ConvertGeotiffArgs) -> Result<(), String> {
         )
         .map_err(|e| e.to_string())?;
 
-    println!("Conversion successful");
-    println!("  Input:      {}", args.input.display());
-    println!("  Output:     {}", args.output.display());
-    println!("  Levels:     {:?}", backend.levels());
-
-    if args.report {
-        print!("{source_report}");
-        print!("{conversion_report}");
+        println!("Conversion successful");
+        println!("  Input (Zarr):    {}", args.input.display());
+        println!("  Output:          {}", args.output.display());
+        println!("  Levels:          {:?}", backend.levels());
+    } else {
+        return Err(format!(
+            "input path does not exist or is invalid: {}",
+            args.input.display()
+        ));
     }
 
     Ok(())

--- a/gp-encoding/src/main.rs
+++ b/gp-encoding/src/main.rs
@@ -13,7 +13,7 @@ use clap::{Args, Parser, Subcommand};
 use geoplegma::types::{DggrsUid, Point, RefinementLevel};
 use gp_encoding::{
     Compression, StorageBackend, ZarrBackend, convert_dggrs_store_to_backend,
-    convert_geotiff_file_to_backend, format_value, query_value_for_point,
+    convert_to_backend, format_value, query_value_for_point,
 };
 
 #[derive(Parser, Debug)]
@@ -29,7 +29,7 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Convert a GeoTIFF file or existing DGGRS Zarr store into a Zarr-backed encoded dataset.
+    /// Convert a GDAL-supported dataset or existing DGGRS Zarr store into a Zarr-backed encoded dataset.
     Convert(ConvertArgs),
     /// Add a coarser resolution level by aggregating an existing level.
     AddLevel(AddLevelArgs),
@@ -44,9 +44,12 @@ struct ConvertArgs {
     /// DGGRS to use for the output dataset.
     #[arg(short, long)]
     dggrs: DggrsUid,
-    /// Input GeoTIFF path or existing Zarr store directory path.
+    /// Input GDAL dataset path/connection string, or existing Zarr store directory path.
     #[arg(short, long)]
     input: PathBuf,
+    /// Optional subdataset variable name to select (for multi-variable formats like NetCDF/HDF5).
+    #[arg(long)]
+    subdataset: Option<String>,
     /// Output Zarr store path.
     #[arg(short, long, default_value = "./tmp/gp_encoding_convert")]
     output: PathBuf,
@@ -123,26 +126,10 @@ fn run_convert(args: ConvertArgs) -> Result<(), String> {
         })?;
     }
 
-    if args.input.is_file() {
-        let (backend, source_report, conversion_report) =
-            convert_geotiff_file_to_backend::<ZarrBackend>(
-                &args.input,
-                &args.output,
-                args.dggrs,
-                args.compression,
-            )
-            .map_err(|e| e.to_string())?;
-
-        println!("Conversion successful");
-        println!("  Input (GeoTIFF): {}", args.input.display());
-        println!("  Output:          {}", args.output.display());
-        println!("  Levels:          {:?}", backend.levels());
-
-        if args.report {
-            print!("{source_report}");
-            print!("{conversion_report}");
+    if args.input.is_dir() {
+        if args.subdataset.is_some() {
+            return Err("Cannot specify --subdataset when converting an existing Zarr store directory.".to_string());
         }
-    } else if args.input.is_dir() {
         let backend = convert_dggrs_store_to_backend::<ZarrBackend>(
             &args.input,
             &args.output,
@@ -156,10 +143,28 @@ fn run_convert(args: ConvertArgs) -> Result<(), String> {
         println!("  Output:          {}", args.output.display());
         println!("  Levels:          {:?}", backend.levels());
     } else {
-        return Err(format!(
-            "input path does not exist or is invalid: {}",
-            args.input.display()
-        ));
+        let (backend, source_report, conversion_report) =
+            convert_to_backend::<ZarrBackend>(
+                &args.input.to_string_lossy(),
+                args.subdataset.as_deref(),
+                &args.output,
+                args.dggrs,
+                args.compression,
+            )
+            .map_err(|e| e.to_string())?;
+
+        println!("Conversion successful");
+        println!("  Input (GDAL):    {}", args.input.display());
+        if let Some(sub) = &args.subdataset {
+            println!("  Subdataset:      {}", sub);
+        }
+        println!("  Output:          {}", args.output.display());
+        println!("  Levels:          {:?}", backend.levels());
+
+        if args.report {
+            print!("{source_report}");
+            print!("{conversion_report}");
+        }
     }
 
     Ok(())

--- a/gp-encoding/src/zarr.rs
+++ b/gp-encoding/src/zarr.rs
@@ -241,7 +241,7 @@ impl ZarrBackend {
         let aperture = u64::from(self.metadata.dggrs.spec().aperture);
         let data_type_size_bytes = self.metadata.attributes.first().map(|a| a.dtype.byte_size()).unwrap_or(1);
 
-        let (target_chunk_level, chunk_size) = crate::geotiff_convert::choose_best_chunk_level_and_size(
+        let (target_chunk_level, chunk_size) = crate::convert::choose_best_chunk_level_and_size(
             RefinementLevel::new(target_level_i32)?,
             min_chunk_level,
             max_relative_depth_allowed,

--- a/viewer-3d/src/App.tsx
+++ b/viewer-3d/src/App.tsx
@@ -110,7 +110,7 @@ const countriesBordersLayer = new GeoJsonLayer({
 });
 
 function App() {
-  const [storePath, setStorePath] = useState('./tmp/gp_encoding_geotiff_convert');
+  const [storePath, setStorePath] = useState('./tmp/gp_encoding_convert');
   const [levels, setLevels] = useState<number[]>([]);
   const [level, setLevel] = useState<number | null>(null);
   const [cells, setCells] = useState<any[]>([]);


### PR DESCRIPTION
Replaced the `convert-geotiff` command with `convert` with expanded functionality
- Allows converting any file supported by GDAL into the Geoplegma format.
- Supports converting exiting Geoplegma files from one DGGRS to another.
- New `--subdatasets` parameter for file formats that use it (e.g. NetCDF)

Closes #125

Steps:
- [x] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [x] Add README documentation of what's done in the PR, if needed.
- [x] Request review
