### PR TITLE
Add threads option in gp-encoding

### DIFF
--- a/gp-encoding/src/main.rs
+++ b/gp-encoding/src/main.rs
@@ -56,6 +56,9 @@ struct ConvertGeotiffArgs {
     /// Print conversion statistics after a successful conversion.
     #[arg(long)]
     report: bool,
+    /// Limit the number of threads used.
+    #[arg(long)]
+    threads: Option<usize>,
 }
 
 #[derive(Args, Debug)]
@@ -123,14 +126,25 @@ fn run_convert_geotiff(args: ConvertGeotiffArgs) -> Result<(), String> {
         })?;
     }
 
-    let (backend, source_report, conversion_report) =
+    let convert_fn = || {
         convert_geotiff_file_to_backend::<ZarrBackend>(
             &args.input,
             &args.output,
             args.dggrs,
             args.compression,
         )
-        .map_err(|e| e.to_string())?;
+    };
+
+    let (backend, source_report, conversion_report) = if let Some(threads) = args.threads {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build()
+            .map_err(|e| format!("failed to initialize rayon thread pool: {e}"))?;
+        pool.install(convert_fn)
+    } else {
+        convert_fn()
+    }
+    .map_err(|e| e.to_string())?;
 
     println!("Conversion successful");
     println!("  Input:      {}", args.input.display());


### PR DESCRIPTION
Added a new option `--threads` for the conversion command in gp-encoding, that limits the amount of threads used by rayon.

Related to #127

Steps:
- [x] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [x] Add README documentation of what's done in the PR, if needed.
- [x] Request review
