### PR TITLE
FEATURE: Hex9 (H9) adapter (libhex9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,10 @@ authors = ["GeoPlegma Developers", "GeoInsight"]
 license = "MIT OR Apache-2.0"
 edition = "2024"
 readme = "README.md"
+
+# Local override: the published dggal-0.0.6 branch does not build on macOS
+# (eC parser vs Clang block `^` syntax in SDK headers; hardcoded obj/linux/lib).
+# This worktree is dggal-0.0.6 (commit fb58cf05) with the macOS build fixes
+# applied to build.rs. Remove once the fixes land upstream.
+[patch."https://github.com/GeoPlegma/dggal-rust.git"]
+dggal-rust = { path = "../dggal-rust-0.0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,3 @@ authors = ["GeoPlegma Developers", "GeoInsight"]
 license = "MIT OR Apache-2.0"
 edition = "2024"
 readme = "README.md"
-
-# Local override: the published dggal-0.0.6 branch does not build on macOS
-# (eC parser vs Clang block `^` syntax in SDK headers; hardcoded obj/linux/lib).
-# This worktree is dggal-0.0.6 (commit fb58cf05) with the macOS build fixes
-# applied to build.rs. Remove once the fixes land upstream.
-[patch."https://github.com/GeoPlegma/dggal-rust.git"]
-dggal-rust = { path = "../dggal-rust-0.0.6" }

--- a/geoplegma/Cargo.toml
+++ b/geoplegma/Cargo.toml
@@ -21,6 +21,8 @@ rand = "0.8.5"
 tracing = "0.1.41"
 h3o = { version = "0.8.0", features = ["geo"] }
 dggal-rust = { git = "https://github.com/GeoPlegma/dggal-rust.git", branch = "dggal-0.0.6" }
+# libhex9 FFI bindings — the Hex9 / H9 DGGRS backend (the -sys crate lives at geoplegma/).
+hex9-sys = { git = "https://github.com/MrBenGriffin/libhex9", tag = "v1.0.0" }
 rayon = "1.10.0"
 thiserror = "2.0.12"
 once_cell = "1.21.0"
@@ -32,6 +34,8 @@ serde = ["dep:serde"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+# Direct FFI access in tests/hex9.rs to exercise libhex9's enumeration ceiling.
+hex9-sys = { git = "https://github.com/MrBenGriffin/libhex9", tag = "v1.0.0" }
 
 [[bench]]
 name = "dggrs"

--- a/geoplegma/src/adapters/hex9/common.rs
+++ b/geoplegma/src/adapters/hex9/common.rs
@@ -1,0 +1,245 @@
+// Copyright 2025 contributors to the GeoPlegma project.
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
+//
+// Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
+// discretion. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Safe, idiomatic wrappers over the libhex9 C ABI (`hex9-sys`), plus the
+//! `Zone`/`Zones` builder. All of libhex9's state is read-only after
+//! [`super::context::ensure_initialised`], so these helpers are thread-safe.
+//!
+//! A Hex9 cell is addressed by a 16-byte UUID. The **full** UUID (from
+//! `hex9_encode`) is the reversible load-bearer used for traversal; the
+//! canonical **bin** at a layer is the GeoPlegma `ZoneId`. libhex9 spells the
+//! bin as the keyed label `"<x_list>.<T>"` (e.g. `"43527.4"`); the adapter
+//! stores it dot-less (`"435274"`) so the deepest (L30) id stays within the
+//! 32-character `ZoneId` limit, re-inserting the `.` only when calling libhex9
+//! (see [`compact`] / [`keyed_from_compact`]).
+
+use crate::api::DggrsApiConfig;
+use crate::error::hex9::Hex9Error;
+use crate::types::{Point, Region, Zone, ZoneId, Zones};
+use geo::GeodesicArea;
+use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
+
+pub type Uuid = [u8; 16];
+
+/// Deepest addressable layer of the linked libhex9 (30 reclaimed / 29 legacy).
+pub fn lmax() -> i32 {
+    // SAFETY: pure accessor, no arguments.
+    unsafe { hex9_sys::hex9_lmax() }
+}
+
+/// Encode (lon, lat) degrees to the full, reversible deepest-layer UUID.
+pub fn encode(lon: f64, lat: f64) -> Uuid {
+    let mut out = [0u8; 16];
+    // SAFETY: out is a valid 16-byte buffer.
+    unsafe {
+        hex9_sys::hex9_encode(lon, lat, out.as_mut_ptr());
+    }
+    out
+}
+
+/// Decode a UUID to its representative (lon, lat) in degrees. Bins resolve to
+/// the cell centroid via the (post-L30) exact identity path.
+pub fn decode(uuid: &Uuid) -> (f64, f64) {
+    let (mut lon, mut lat) = (0.0f64, 0.0f64);
+    // SAFETY: uuid is 16 bytes; lon/lat are valid out-pointers.
+    unsafe {
+        hex9_sys::hex9_decode(uuid.as_ptr(), &mut lon, &mut lat);
+    }
+    (lon, lat)
+}
+
+/// Canonical bin (cell key) of `uuid` at `layer`.
+pub fn bin_at(uuid: &Uuid, layer: i32) -> Uuid {
+    let mut out = [0u8; 16];
+    // SAFETY: both buffers are 16 bytes.
+    unsafe {
+        hex9_sys::hex9_bin(uuid.as_ptr(), layer, out.as_mut_ptr());
+    }
+    out
+}
+
+/// Recover a full (reversible) UUID for the cell a bin names: decode to its
+/// interior centroid, then re-encode. Round-trips exactly (`bin(full, L) ==
+/// bin`) on the L30 layout — this is the validated traversal primitive.
+pub fn full_from_bin(bin: &Uuid) -> Uuid {
+    let (lon, lat) = decode(bin);
+    encode(lon, lat)
+}
+
+/// Human/`ZoneId` label `"<x_list>.<T>"` for the canonical bin of `uuid` at
+/// `layer`. Accepts full or bin UUIDs (full ones are resolved to their bin).
+pub fn label_key(uuid: &Uuid, layer: i32) -> Result<String, Hex9Error> {
+    let mut buf = [0 as c_char; 48];
+    // SAFETY: buf is a valid writable buffer of the stated length.
+    let n = unsafe {
+        hex9_sys::hex9_label_key(uuid.as_ptr(), layer, buf.as_mut_ptr(), buf.len())
+    };
+    if n < 0 {
+        return Err(Hex9Error::Ffi { call: "hex9_label_key", rc: n as i64 });
+    }
+    // SAFETY: hex9_label_key NUL-terminates within buf on success.
+    let s = unsafe { CStr::from_ptr(buf.as_ptr()) }
+        .to_string_lossy()
+        .into_owned();
+    Ok(s)
+}
+
+/// Parse a canonical label back to its bin UUID and layer.
+pub fn parse_label(label: &str) -> Result<(Uuid, i32), Hex9Error> {
+    let c = CString::new(label).map_err(|_| Hex9Error::NulInLabel(label.to_string()))?;
+    let mut out = [0u8; 16];
+    // SAFETY: c is a valid NUL-terminated string; out is 16 bytes.
+    let layer = unsafe { hex9_sys::hex9_parse_label(c.as_ptr(), out.as_mut_ptr()) };
+    if layer < 0 {
+        return Err(Hex9Error::InvalidZoneId(label.to_string()));
+    }
+    Ok((out, layer))
+}
+
+/// Closed ring (lon/lat degrees) of the cell `uuid` at `layer`. `densify >= 0`
+/// subdivides each edge into 3^densify segments.
+pub fn cell_ring(uuid: &Uuid, layer: i32, densify: i32) -> Result<Vec<Point>, Hex9Error> {
+    // SAFETY: pure arithmetic accessor.
+    let npoints = unsafe { hex9_sys::hex9_ring_npoints(densify) };
+    if npoints <= 0 {
+        return Err(Hex9Error::Ffi { call: "hex9_ring_npoints", rc: npoints as i64 });
+    }
+    let mut buf = vec![0f64; npoints as usize * 2];
+    // SAFETY: buf holds 2*npoints doubles, matching max_points = npoints.
+    let got = unsafe {
+        hex9_sys::hex9_cell_ring(uuid.as_ptr(), layer, densify, buf.as_mut_ptr(), npoints)
+    };
+    if got < 0 {
+        return Err(Hex9Error::Ffi { call: "hex9_cell_ring", rc: got as i64 });
+    }
+    // Interleaved (lon, lat) pairs -> Point { lat, lon }.
+    let pts = (0..got as usize)
+        .map(|i| Point::new(buf[2 * i + 1], buf[2 * i]))
+        .collect();
+    Ok(pts)
+}
+
+/// The (up to 6) edge-adjacent neighbour cells of a **full** UUID, as canonical
+/// bin UUIDs at `layer`. (libhex9 rejects bin input here — neighbours are keys,
+/// not addresses; pass the full UUID.)
+pub fn neighbors_of(full: &Uuid, layer: i32) -> Vec<Uuid> {
+    let mut buf = [0u8; 6 * 16];
+    // SAFETY: buf is 6*16 bytes as the ABI requires.
+    let n = unsafe { hex9_sys::hex9_neighbors(full.as_ptr(), layer, buf.as_mut_ptr()) };
+    if n < 0 {
+        return Vec::new();
+    }
+    (0..n as usize)
+        .map(|i| {
+            let mut u = [0u8; 16];
+            u.copy_from_slice(&buf[i * 16..i * 16 + 16]);
+            u
+        })
+        .collect()
+}
+
+/// libhex9's keyed label `"<x_list>.<T>"` -> GeoPlegma's compact `ZoneId`
+/// `"<x_list><T>"`. The single 3-bit key-tail character is always last, so the
+/// `.` is pure punctuation; dropping it keeps the deepest (L30) label within the
+/// 32-character `ZoneId::new_str` limit (31 body + 1 tail = 32, vs 33 with the
+/// dot). Any trailing whitespace is trimmed.
+fn compact(keyed: &str) -> String {
+    keyed.trim().replace('.', "")
+}
+
+/// Inverse of [`compact`]: re-insert the `.` before the final tail character so
+/// `hex9_parse_label` sees its keyed form. Idempotent on already-dotted input.
+pub fn keyed_from_compact(id: &str) -> String {
+    let id = id.trim();
+    if id.contains('.') || id.len() < 2 {
+        id.to_string()
+    } else {
+        // Body digits and the tail are all single-byte ASCII, so byte-slicing
+        // at len-1 is safe; the tail is exactly one character.
+        let split = id.len() - 1;
+        format!("{}.{}", &id[..split], &id[split..])
+    }
+}
+
+/// The compact `ZoneId` (`StrId`) naming the canonical bin of `uuid` at `layer`.
+pub fn zone_id_of(uuid: &Uuid, layer: i32) -> Result<ZoneId, Hex9Error> {
+    let id = compact(&label_key(uuid, layer)?);
+    ZoneId::new_str(&id).map_err(|_| Hex9Error::InvalidZoneId(id))
+}
+
+/// Build `Zones` from a set of **full** UUIDs at a single `layer`, honouring the
+/// output `config`. Children are always `None`: libhex9 has no direct children
+/// primitive yet — descendants come from `zones_from_parent` (grid + ancestry).
+pub fn to_zones(fulls: &[Uuid], layer: i32, cfg: DggrsApiConfig) -> Result<Zones, Hex9Error> {
+    let mut zones = Vec::with_capacity(fulls.len());
+
+    for full in fulls {
+        let bin = bin_at(full, layer);
+        let id = zone_id_of(full, layer)?;
+
+        // One ring serves region, area and vertex_count (densify 0 = corners).
+        let ring = if cfg.region || cfg.area_sqm || cfg.vertex_count {
+            Some(cell_ring(full, layer, 0)?)
+        } else {
+            None
+        };
+
+        let region = if cfg.region || cfg.area_sqm {
+            ring.as_ref().map(|p| Region::new(p.clone()))
+        } else {
+            None
+        };
+
+        let area_sqm = if cfg.area_sqm {
+            region
+                .as_ref()
+                .map(|r| r.to_geo_polygon().geodesic_area_unsigned())
+        } else {
+            None
+        };
+
+        let vertex_count = if cfg.vertex_count {
+            // The ring is closed (last == first); unique vertices = len - 1.
+            ring.as_ref().map(|p| p.len().saturating_sub(1) as u32)
+        } else {
+            None
+        };
+
+        let center = if cfg.center {
+            let (lon, lat) = decode(&bin);
+            Some(Point::new(lat, lon))
+        } else {
+            None
+        };
+
+        let neighbors = if cfg.neighbors {
+            Some(
+                neighbors_of(full, layer)
+                    .iter()
+                    .map(|nb| zone_id_of(nb, layer))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )
+        } else {
+            None
+        };
+
+        zones.push(Zone {
+            id,
+            region,
+            center,
+            vertex_count,
+            children: None,
+            neighbors,
+            area_sqm,
+        });
+    }
+
+    Ok(Zones { zones })
+}

--- a/geoplegma/src/adapters/hex9/context.rs
+++ b/geoplegma/src/adapters/hex9/context.rs
@@ -1,0 +1,30 @@
+// Copyright 2025 contributors to the GeoPlegma project.
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
+//
+// Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
+// discretion. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! One-time libhex9 lifecycle. `hex9_warp_init` builds the authalic-warp
+//! interpolation state; it is idempotent and read-only afterwards, so the whole
+//! library is thread-safe once initialised (the adapter is `Send + Sync`).
+
+use std::os::raw::c_char;
+use std::sync::Once;
+
+static WARP_INIT: Once = Once::new();
+
+/// Initialise the embedded authalic warp exactly once. Failure is non-fatal —
+/// libhex9 falls back to the identity warp — and cannot occur with the blob
+/// compiled into the static library, so we don't surface it.
+pub fn ensure_initialised() {
+    WARP_INIT.call_once(|| {
+        let mut err = [0 as c_char; 256];
+        // SAFETY: err is a valid, correctly-sized writable buffer.
+        unsafe {
+            hex9_sys::hex9_warp_init(err.as_mut_ptr(), err.len());
+        }
+    });
+}

--- a/geoplegma/src/adapters/hex9/grids.rs
+++ b/geoplegma/src/adapters/hex9/grids.rs
@@ -1,0 +1,283 @@
+// Copyright 2025 contributors to the GeoPlegma project.
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
+//
+// Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
+// discretion. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::adapters::hex9::common::{
+    bin_at, cell_ring, encode, full_from_bin, keyed_from_compact, parse_label, to_zones, Uuid,
+};
+use crate::adapters::hex9::context::ensure_initialised;
+use crate::api::{DggrsApi, DggrsApiConfig};
+use crate::error::DggrsError;
+use crate::error::hex9::Hex9Error;
+use crate::types::{
+    BoundingBox, DggrsName, DggrsUid, Point, RefinementLevel, RelativeDepth, ZoneId, Zones,
+};
+use std::ffi::c_char;
+
+/// Cap on a single grid enumeration (guards a runaway whole-world deep grid).
+/// libhex9 bails mid-BFS once this is exceeded, so it fails fast rather than
+/// trying to materialise 12·9^layer cells. Hefty but bounded: ~100M cells is a
+/// few GB of geometry — a guard-rail, not a target (real queries are far smaller).
+const GRID_MAX_CELLS: i64 = 100_000_000;
+
+/// The libhex9-backed (Hex9 / H9 aperture-9 hexagonal DGGS) adapter.
+pub struct Hex9Impl {
+    pub id: DggrsUid,
+}
+
+impl Hex9Impl {
+    pub fn new(id: DggrsUid) -> Self {
+        ensure_initialised();
+        Self { id }
+    }
+
+    #[inline]
+    fn grid_name(&self) -> DggrsName {
+        self.id.spec().name
+    }
+
+    fn check_level(&self, level: RefinementLevel) -> Result<(), DggrsError> {
+        if level > self.max_refinement_level()? {
+            return Err(DggrsError::RefinementLevelLimitReached {
+                grid_name: self.grid_name().to_string(),
+                requested: level,
+                maximum: self.max_refinement_level()?,
+            });
+        }
+        Ok(())
+    }
+
+    /// Hex9-specific (NOT part of the `DggrsApi` contract): the boundary ring of
+    /// a single zone, densified by `densify` (0..=9 → each edge split into
+    /// 3^densify segments, i.e. `6 * 3^densify + 1` points). The generic
+    /// `DggrsApiConfig` only carries a densify on/off bool and can't express the
+    /// amount, so a caller holding a concrete `Hex9Impl` uses this to choose it.
+    pub fn zone_ring(&self, zone_id: ZoneId, densify: i32) -> Result<Vec<Point>, DggrsError> {
+        let (bin, layer) = resolve(&zone_id)?;
+        let full = full_from_bin(&bin);
+        Ok(cell_ring(&full, layer, densify)?)
+    }
+}
+
+/// RAII handle over a libhex9 grid enumeration.
+struct Grid {
+    ptr: *mut hex9_sys::hex9_grid,
+}
+
+impl Grid {
+    fn create(bbox: &BoundingBox, layer: i32) -> Result<Self, Hex9Error> {
+        let mut err = [0 as c_char; 256];
+        // SAFETY: all scalars by value; err is a valid writable buffer.
+        let ptr = unsafe {
+            hex9_sys::hex9_grid_create(
+                bbox.min_lon,
+                bbox.min_lat,
+                bbox.max_lon,
+                bbox.max_lat,
+                layer,
+                0, // densify default; rings are built on demand
+                GRID_MAX_CELLS,
+                err.as_mut_ptr(),
+                err.len(),
+            )
+        };
+        if ptr.is_null() {
+            // SAFETY: err is NUL-terminated by the ABI on failure.
+            let msg = unsafe { std::ffi::CStr::from_ptr(err.as_ptr()) }
+                .to_string_lossy()
+                .into_owned();
+            return Err(Hex9Error::Grid(msg));
+        }
+        Ok(Self { ptr })
+    }
+
+    fn count(&self) -> i32 {
+        // SAFETY: ptr is a live handle.
+        unsafe { hex9_sys::hex9_grid_count(self.ptr as *const _) }
+    }
+
+    /// Full, reversible identity UUID of grid cell `i`.
+    fn cell_id(&self, i: i32) -> Uuid {
+        let mut out = [0u8; 16];
+        // SAFETY: i is in 0..count; out is 16 bytes.
+        unsafe { hex9_sys::hex9_grid_cell_id(self.ptr as *const _, i, out.as_mut_ptr()) };
+        out
+    }
+}
+
+impl Drop for Grid {
+    fn drop(&mut self) {
+        // SAFETY: ptr was returned by hex9_grid_create and not yet freed.
+        unsafe { hex9_sys::hex9_grid_destroy(self.ptr) };
+    }
+}
+
+/// Min/max lon/lat of a ring, padded outward so the centroid-in-bbox grid
+/// filter cannot miss the cell's own descendants on the boundary.
+fn bbox_of(ring: &[Point]) -> BoundingBox {
+    let mut min_lon = f64::INFINITY;
+    let mut min_lat = f64::INFINITY;
+    let mut max_lon = f64::NEG_INFINITY;
+    let mut max_lat = f64::NEG_INFINITY;
+    for p in ring {
+        min_lon = min_lon.min(p.lon);
+        max_lon = max_lon.max(p.lon);
+        min_lat = min_lat.min(p.lat);
+        max_lat = max_lat.max(p.lat);
+    }
+    let pad = 1e-9_f64.max((max_lon - min_lon) * 1e-6);
+    BoundingBox::new(
+        (min_lon - pad).max(-180.0),
+        (min_lat - pad).max(-90.0),
+        (max_lon + pad).min(180.0),
+        (max_lat + pad).min(90.0),
+    )
+}
+
+/// Resolve a `ZoneId` to its canonical bin UUID and layer. Hex9 ids are textual
+/// labels (`"<x_list>.<T>"`); integer ids are not a Hex9 address.
+fn resolve(zone_id: &ZoneId) -> Result<(Uuid, i32), Hex9Error> {
+    match zone_id {
+        ZoneId::StrId(s) => parse_label(&keyed_from_compact(s)),
+        ZoneId::HexId(h) => parse_label(&keyed_from_compact(h.as_str())),
+        ZoneId::IntId(i) => Err(Hex9Error::UnsupportedZoneId(*i)),
+    }
+}
+
+impl DggrsApi for Hex9Impl {
+    fn zones_from_bbox(
+        &self,
+        refinement_level: RefinementLevel,
+        bbox: Option<BoundingBox>,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError> {
+        let cfg = config.unwrap_or_default();
+        self.check_level(refinement_level)?;
+        let layer = refinement_level.get();
+        let extent = bbox.unwrap_or(BoundingBox::WORLD);
+
+        let grid = Grid::create(&extent, layer)?;
+        let count = grid.count();
+        let fulls: Vec<Uuid> = (0..count).map(|i| grid.cell_id(i)).collect();
+        Ok(to_zones(&fulls, layer, cfg)?)
+    }
+
+    fn zone_from_point(
+        &self,
+        refinement_level: RefinementLevel,
+        point: Point,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError> {
+        let cfg = config.unwrap_or_default();
+        self.check_level(refinement_level)?;
+        let full = encode(point.lon, point.lat);
+        Ok(to_zones(&[full], refinement_level.get(), cfg)?)
+    }
+
+    fn zones_from_parent(
+        &self,
+        relative_depth: RelativeDepth,
+        parent_zone_id: ZoneId,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError> {
+        let cfg = config.unwrap_or_default();
+
+        if relative_depth > self.max_relative_depth()? {
+            return Err(DggrsError::RelativeDepthLimitReached {
+                grid_name: self.grid_name().to_string(),
+                requested: relative_depth,
+                maximum: self.max_relative_depth()?,
+            });
+        }
+
+        let (parent_bin, parent_layer) = resolve(&parent_zone_id)?;
+        let target = RefinementLevel::new(parent_layer)?.add(relative_depth)?;
+        if target > self.max_refinement_level()? {
+            return Err(DggrsError::RefinementLevelPlusRelativeDepthLimitReached {
+                grid_name: self.grid_name().to_string(),
+                requested: relative_depth,
+                maximum: self.max_refinement_level()?,
+            });
+        }
+
+        // Enumerate the target layer over the parent's bounding box, then keep
+        // only cells whose ancestor at the parent layer IS the parent — exact
+        // containment-based descent (the decode->re-encode->bin traversal rule).
+        let parent_full = full_from_bin(&parent_bin);
+        let ring = cell_ring(&parent_full, parent_layer, 0)?;
+        let grid = Grid::create(&bbox_of(&ring), target.get())?;
+
+        let mut descendants: Vec<Uuid> = Vec::new();
+        for i in 0..grid.count() {
+            let cand = grid.cell_id(i);
+            if bin_at(&cand, parent_layer) == parent_bin {
+                descendants.push(cand);
+            }
+        }
+        Ok(to_zones(&descendants, target.get(), cfg)?)
+    }
+
+    fn primary_parent_from_zone(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError> {
+        let cfg = config.unwrap_or_default();
+        let (bin, layer) = resolve(&zone_id)?;
+        if layer < 1 {
+            return Err(Hex9Error::NoParent.into());
+        }
+
+        // Primary parent = the mode-0 cell that geometrically contains this one,
+        // via decode -> re-encode -> bin(L-1). `primary_parent_from_zone` is
+        // documented as implementation-defined; containment is the Hex9 choice.
+        let full = full_from_bin(&bin);
+        let parent_layer = layer - 1;
+        let parent_bin = bin_at(&full, parent_layer);
+        let parent_full = full_from_bin(&parent_bin);
+        Ok(to_zones(&[parent_full], parent_layer, cfg)?)
+    }
+
+    fn zone_from_id(
+        &self,
+        zone_id: ZoneId,
+        config: Option<DggrsApiConfig>,
+    ) -> Result<Zones, DggrsError> {
+        let cfg = config.unwrap_or_default();
+        let (bin, layer) = resolve(&zone_id)?;
+        let full = full_from_bin(&bin);
+        Ok(to_zones(&[full], layer, cfg)?)
+    }
+
+    fn zone_count(&self, refinement_level: RefinementLevel) -> Result<u64, DggrsError> {
+        // 12 base cells, aperture 9: 12 * 9^level (saturates rather than panics
+        // at the deepest layers, where the exact count overflows u64).
+        let level = refinement_level.get().max(0) as u32;
+        Ok(12u64.saturating_mul(9u64.saturating_pow(level)))
+    }
+
+    fn min_refinement_level(&self) -> Result<RefinementLevel, DggrsError> {
+        Ok(self.id.spec().min_refinement_level)
+    }
+
+    fn max_refinement_level(&self) -> Result<RefinementLevel, DggrsError> {
+        Ok(self.id.spec().max_refinement_level)
+    }
+
+    fn default_refinement_level(&self) -> Result<RefinementLevel, DggrsError> {
+        Ok(self.id.spec().default_refinement_level)
+    }
+
+    fn max_relative_depth(&self) -> Result<RelativeDepth, DggrsError> {
+        Ok(self.id.spec().max_relative_depth)
+    }
+
+    fn default_relative_depth(&self) -> Result<RelativeDepth, DggrsError> {
+        Ok(self.id.spec().default_relative_depth)
+    }
+}

--- a/geoplegma/src/adapters/hex9/mod.rs
+++ b/geoplegma/src/adapters/hex9/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2025 contributors to the GeoPlegma project.
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
+//
+// Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
+// discretion. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! The libhex9-backed Hex9 (H9) DGGRS adapter — an aperture-9 hexagonal grid
+//! with self-contained 16-byte UUID addresses, bound via the `hex9-sys` crate.
+
+pub mod common;
+pub mod context;
+pub mod grids;

--- a/geoplegma/src/adapters/mod.rs
+++ b/geoplegma/src/adapters/mod.rs
@@ -10,3 +10,4 @@
 pub mod dggrid;
 pub mod dggal;
 pub mod h3o;
+pub mod hex9;

--- a/geoplegma/src/constants.rs
+++ b/geoplegma/src/constants.rs
@@ -10,7 +10,7 @@
 use crate::types::{
     DggrsImplementation, DggrsName, DggrsSpec, DggrsUid, RefinementLevel, RelativeDepth,
 };
-pub const DGGRS_SPECS: [DggrsSpec; 11] = [
+pub const DGGRS_SPECS: [DggrsSpec; 12] = [
     DggrsSpec {
         id: DggrsUid::ISEA3HDGGRID,
         name: DggrsName::ISEA3H,
@@ -175,5 +175,24 @@ pub const DGGRS_SPECS: [DggrsSpec; 11] = [
         default_refinement_level: RefinementLevel::new_const(2),
         max_relative_depth: RelativeDepth::new_const(8),
         default_relative_depth: RelativeDepth::new_const(6),
+    },
+    DggrsSpec {
+        id: DggrsUid::HEX9,
+        name: DggrsName::HEX9,
+        tool: DggrsImplementation::HEX9,
+        title: "Hex9 (H9)",
+        description: "Aperture-9 hexagonal DGGS (libhex9) with self-contained UUID addresses",
+        uri: "https://github.com/MrBenGriffin/libhex9",
+        crs: "",
+        aperture: 9,
+        // Cells/grid run at layers 0..=30 (12 well-defined L0 base hexagons,
+        // through the reclaimed L30 layout); the adapter clamps to the linked
+        // libhex9's hex9_lmax() at runtime.
+        min_refinement_level: RefinementLevel::new_const(0),
+        max_refinement_level: RefinementLevel::new_const(30),
+        default_refinement_level: RefinementLevel::new_const(5),
+        // 9^d grows fast (9^5 = 59049 sub-zones); kept modest by default.
+        max_relative_depth: RelativeDepth::new_const(5),
+        default_relative_depth: RelativeDepth::new_const(2),
     },
 ];

--- a/geoplegma/src/error/hex9.rs
+++ b/geoplegma/src/error/hex9.rs
@@ -1,0 +1,32 @@
+// Copyright 2025 contributors to the GeoPlegma project.
+// Originally authored by Michael Jendryke, GeoInsight (michael.jendryke@geoinsight.ai)
+//
+// Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your
+// discretion. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use thiserror::Error;
+
+/// Error type for the libhex9-backed (Hex9 / H9) adapter.
+#[derive(Debug, Error)]
+pub enum Hex9Error {
+    #[error("libhex9 call '{call}' failed (rc {rc})")]
+    Ffi { call: &'static str, rc: i64 },
+
+    #[error("invalid Hex9 ZoneId '{0}' — expected a canonical label like \"43527.4\"")]
+    InvalidZoneId(String),
+
+    #[error("Hex9 ZoneId must be a textual label (StrId/HexId), got integer id '{0}'")]
+    UnsupportedZoneId(u64),
+
+    #[error("Hex9 grid enumeration failed: {0}")]
+    Grid(String),
+
+    #[error("a Hex9 zone at layer 0 has no parent")]
+    NoParent,
+
+    #[error("Hex9 label contained an interior NUL byte: '{0}'")]
+    NulInLabel(String),
+}

--- a/geoplegma/src/error/mod.rs
+++ b/geoplegma/src/error/mod.rs
@@ -11,12 +11,14 @@ pub mod dggal;
 pub mod dggrid;
 pub mod factory;
 pub mod h3o;
+pub mod hex9;
 pub mod port;
 
 use crate::error::dggal::DggalError;
 use crate::error::dggrid::DggridError;
 use crate::error::factory::FactoryError;
 use crate::error::h3o::H3oError;
+use crate::error::hex9::Hex9Error;
 use crate::types::{RefinementLevel, RelativeDepth};
 use std::num::ParseFloatError;
 use thiserror::Error;
@@ -34,6 +36,9 @@ pub enum DggrsError {
 
     #[error("H3o error: {0}")]
     H3o(#[from] H3oError),
+
+    #[error("HEX9 error: {0}")]
+    Hex9(#[from] Hex9Error),
 
     #[error("Depth must be non-negative, got {0}")]
     DepthBelowZero(i32),

--- a/geoplegma/src/factory.rs
+++ b/geoplegma/src/factory.rs
@@ -8,7 +8,8 @@
 // except according to those terms.
 
 use crate::adapters::{
-    dggal::grids::DggalImpl, dggrid::igeo7::Igeo7Impl, dggrid::isea3h::Isea3hImpl, h3o::h3::H3Impl,
+    dggal::grids::DggalImpl, dggrid::igeo7::Igeo7Impl, dggrid::isea3h::Isea3hImpl,
+    h3o::h3::H3Impl, hex9::grids::Hex9Impl,
 };
 use crate::api::DggrsApi;
 use crate::constants::DGGRS_SPECS;
@@ -39,6 +40,11 @@ pub fn get(id: DggrsUid) -> Result<Arc<dyn DggrsApi>, FactoryError> {
             | DggrsUid::RTEA9R
             | DggrsUid::IVEA7H
             | DggrsUid::IVEA7H_Z7 => Ok(Arc::new(DggalImpl::new(id))), // change DggalImpl::new to take DggrsId
+            _ => Err(DggrsUidError::Unsupported { id }.into()),
+        },
+
+        DggrsImplementation::HEX9 => match id {
+            DggrsUid::HEX9 => Ok(Arc::new(Hex9Impl::new(id))),
             _ => Err(DggrsUidError::Unsupported { id }.into()),
         },
 

--- a/geoplegma/src/types.rs
+++ b/geoplegma/src/types.rs
@@ -95,6 +95,7 @@ pub enum DggrsUid {
     RTEA9R,
     IVEA7H,
     IVEA7H_Z7,
+    HEX9,
 }
 
 impl DggrsUid {
@@ -112,6 +113,7 @@ impl DggrsUid {
             DggrsUid::RTEA9R => 8,
             DggrsUid::IVEA7H => 9,
             DggrsUid::IVEA7H_Z7 => 10,
+            DggrsUid::HEX9 => 11,
         }
     }
 
@@ -159,6 +161,7 @@ pub enum DggrsName {
     RTEA9R,
     IVEA7H,
     IVEA7H_Z7,
+    HEX9,
 }
 impl fmt::Display for DggrsName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -173,6 +176,7 @@ impl fmt::Display for DggrsName {
             DggrsName::RTEA9R => "RTEA9R",
             DggrsName::IVEA7H => "IVEA7H",
             DggrsName::IVEA7H_Z7 => "IVEA7H_Z7",
+            DggrsName::HEX9 => "HEX9",
         };
         f.write_str(s)
     }
@@ -184,6 +188,7 @@ pub enum DggrsImplementation {
     DGGRID,
     DGGAL,
     H3O,
+    HEX9,
 }
 
 impl fmt::Display for DggrsImplementation {
@@ -193,6 +198,7 @@ impl fmt::Display for DggrsImplementation {
             DggrsImplementation::DGGRID => "DGGRID",
             DggrsImplementation::DGGAL => "DGGAL",
             DggrsImplementation::H3O => "H3O",
+            DggrsImplementation::HEX9 => "HEX9",
         };
         f.write_str(s)
     }

--- a/geoplegma/tests/hex9.rs
+++ b/geoplegma/tests/hex9.rs
@@ -1,0 +1,200 @@
+// Copyright 2025 contributors to the GeoPlegma project.
+//
+// Licenced under the Apache Licence, Version 2.0 <LICENCE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENCE-MIT or http://opensource.org/licenses/MIT>, at your discretion.
+
+//! API tests for the Hex9 (libhex9 / H9) adapter.
+//!
+//! Hex9 differs from the other backends:
+//!   * Refinement levels run 0..=30 — the 12 base hexagons are the well-defined
+//!     L0. The *addressing* API (`zone_from_point`, `zone_from_id`,
+//!     `primary_parent_from_zone`) works across the whole range.
+//!   * The *enumeration* API (`zones_from_bbox`, `zones_from_parent`) goes
+//!     through libhex9's `hex9_grid_create`, which the currently linked build
+//!     restricts to layers 1..29 — so L0 / deep layers cannot be enumerated.
+//!   * `to_zones` never populates `children` (libhex9 has no direct children
+//!     enumeration), so the dggal-style children helpers do not apply.
+
+use geoplegma::adapters::hex9::grids::Hex9Impl;
+use geoplegma::api::{DggrsApi, DggrsApiConfig};
+use geoplegma::types::{DggrsUid, Point, RefinementLevel, ZoneId};
+
+const PLAIN: DggrsApiConfig = DggrsApiConfig {
+    area_sqm: false,
+    densify: false,
+    center: false,
+    region: false,
+    children: false,
+    neighbors: false,
+    vertex_count: false,
+};
+
+const POINT: Point = Point { lat: 52.98, lon: 9.06 };
+
+/// Closed-form zone count is 12 · 9^level at every layer, including L0 = the 12
+/// base hexagons.
+#[test]
+fn hex9_zone_count_closed_form() {
+    let hex9 = Hex9Impl::new(DggrsUid::HEX9);
+
+    for level_int in 0..=15 {
+        let level = RefinementLevel::new(level_int).unwrap();
+        let expected = 12u64 * 9u64.pow(level_int as u32);
+
+        assert_eq!(
+            hex9.zone_count(level).unwrap(),
+            expected,
+            "L{level_int}: zone_count must be 12 * 9^{level_int}",
+        );
+    }
+}
+
+/// The closed form must equal the whole-world cell count, including L0 (the 12
+/// base hexagons). Exercises `zones_from_bbox`.
+#[test]
+fn hex9_zone_count_matches_world_enumeration() {
+    let hex9 = Hex9Impl::new(DggrsUid::HEX9);
+
+    for level_int in 0..=3 {
+        let level = RefinementLevel::new(level_int).unwrap();
+
+        let expected = hex9.zone_count(level).unwrap();
+        // Default config (renders cell rings) — also smoke-tests L0 geometry.
+        let zones = hex9.zones_from_bbox(level, None, None).unwrap();
+
+        assert_eq!(
+            expected,
+            zones.zones.len() as u64,
+            "L{level_int}: closed-form zone_count must equal the whole-world grid size",
+        );
+    }
+}
+
+/// A zone addressed by a point must survive a textual round-trip: re-resolving
+/// its own id via `zone_from_id` yields the same id. Exercises `zone_from_point`
+/// + `zone_from_id` and the label <-> bin encoding across the full 0..=30
+/// addressing range (these use encode()/labels, not grid_create).
+#[test]
+fn hex9_zone_from_id_round_trips() {
+    let hex9 = Hex9Impl::new(DggrsUid::HEX9);
+    let max = hex9.max_refinement_level().unwrap().get();
+
+    for rf in 0..=max {
+        let level = RefinementLevel::new(rf).unwrap();
+        let id = point_zone(&hex9, level.get(), POINT);
+
+        let round_tripped = hex9
+            .zone_from_id(id.clone(), Some(PLAIN))
+            .unwrap()
+            .zones
+            .first()
+            .unwrap()
+            .id
+            .clone();
+
+        assert_eq!(id, round_tripped, "L{rf}: zone_from_id must round-trip the zone id");
+    }
+}
+
+/// `primary_parent_from_zone` steps down exactly one level per call: iterated
+/// from a deep cell it must reach an L0 base hexagon in exactly `deep` steps,
+/// after which an L0 cell has no parent. Exercises `zone_from_point` +
+/// `primary_parent_from_zone` over its whole range.
+#[test]
+fn hex9_primary_parent_climbs_to_base() {
+    let hex9 = Hex9Impl::new(DggrsUid::HEX9);
+    let deep = 20;
+
+    let mut zone = point_zone(&hex9, deep, POINT);
+    for _ in 0..deep {
+        zone = primary_parent(&hex9, zone);
+    }
+
+    // `zone` is now the L0 ancestor; an L0 base hexagon has no primary parent.
+    assert!(
+        hex9.primary_parent_from_zone(zone, Some(PLAIN)).is_err(),
+        "an L0 base hexagon must have no primary parent",
+    );
+}
+
+/// An L0 base hexagon's neighbours are queryable (the libhex9 kring layer gate
+/// now admits L0). Exercises `zone_from_point` with `neighbors` at L0.
+#[test]
+fn hex9_l0_base_hexagon_has_neighbours() {
+    let hex9 = Hex9Impl::new(DggrsUid::HEX9);
+    let cfg = DggrsApiConfig { neighbors: true, ..PLAIN };
+
+    let zone = hex9
+        .zone_from_point(RefinementLevel::new(0).unwrap(), POINT, Some(cfg))
+        .unwrap()
+        .zones
+        .into_iter()
+        .next()
+        .unwrap();
+
+    let neighbours = zone.neighbors.expect("neighbours were requested");
+    assert!(
+        !neighbours.is_empty(),
+        "an L0 base hexagon must have queryable neighbours",
+    );
+}
+
+/// A deep whole-world enumeration must bail against the cell ceiling instead of
+/// trying to materialise 12·9^level cells. Tested at the libhex9 FFI boundary
+/// with a tiny budget so the bail is instant (the adapter's real ceiling is
+/// 100M, which would be valid but multi-GB to drive — the mechanism is the same).
+#[test]
+fn hex9_grid_create_bails_against_max_cells() {
+    let mut err = [0 as std::os::raw::c_char; 256];
+    // L20 over the whole globe is ~1.5e19 cells; a 10k budget must bail at once.
+    let grid = unsafe {
+        hex9_sys::hex9_grid_create(
+            -180.0, -90.0, 180.0, 90.0, // WORLD
+            /*layer=*/ 20,
+            /*densify=*/ 0,
+            /*max_cells=*/ 10_000,
+            err.as_mut_ptr(),
+            err.len(),
+        )
+    };
+    assert!(
+        grid.is_null(),
+        "a deep whole-world enumeration must bail against the max_cells budget",
+    );
+}
+
+/// Hex9-specific densify control via an inherent method on the concrete type
+/// (outside the `DggrsApi` contract). `densify` splits each edge into 3^densify
+/// segments, so the ring has `6 * 3^densify + 1` points.
+#[test]
+fn hex9_zone_ring_densify_selects_resolution() {
+    let hex9 = Hex9Impl::new(DggrsUid::HEX9);
+    let zone = point_zone(&hex9, 6, POINT);
+
+    let corners = hex9.zone_ring(zone.clone(), 0).unwrap();
+    let dense = hex9.zone_ring(zone, 2).unwrap();
+
+    assert_eq!(corners.len(), 7, "densify 0 = 6 hexagon corners + closing point");
+    assert_eq!(dense.len(), 55, "densify 2 = 6 * 3^2 + 1 points");
+}
+
+fn point_zone(hex9: &Hex9Impl, level: i32, point: Point) -> ZoneId {
+    hex9.zone_from_point(RefinementLevel::new(level).unwrap(), point, Some(PLAIN))
+        .unwrap()
+        .zones
+        .first()
+        .unwrap()
+        .id
+        .clone()
+}
+
+fn primary_parent(hex9: &Hex9Impl, zone: ZoneId) -> ZoneId {
+    hex9.primary_parent_from_zone(zone, Some(PLAIN))
+        .unwrap()
+        .zones
+        .first()
+        .unwrap()
+        .id
+        .clone()
+}


### PR DESCRIPTION
**Kanban item [GeoPlegma 19](https://github.com/orgs/GeoPlegma/projects/3/views/2?pane=issue&itemId=204436735&issue=GeoPlegma%7CGeoPlegma%7C138)**
This is a new adapter - so 'feature'

 Adds the Hex9 / H9 aperture-9 hexagonal DGGS as a DGGRS backend, backed by
  libhex9 through the hex9-sys FFI crate. 
  
  ## What's included
  - `adapters/hex9/` — the adapter, implementing the full DggrsApi contract
    (zones_from_bbox, zone_from_point, zones_from_parent, 
    primary_parent_from_zone, zone_from_id, zone_count, level/depth getters).
  - Wiring: HEX9 DggrsSpec (aperture 9, refinement levels 0..=30), the
    DggrsUid / DggrsName / DggrsImplementation::HEX9 variants, the factory
    arm, and Hex9Error.
  - Dependency: hex9-sys pinned to libhex9 v1.0.0 (git tag) https://github.com/MrBenGriffin/libhex9
  - tests/hex9.rs — 7 tests: zone_count closed form (12·9^L) vs whole-world
    enumeration incl. L0; zone_from_id round-trip L0..=30; primary_parent
    climbs to an L0 base hexagon; L0 base-hexagon neighbours; densify-
    controlled ring resolution; and the enumeration cell-ceiling bail.
    
  ## Notes for reviewers
  - Hex9 ids are self-contained UUID labels; refinement levels run 0..=30
  - to_zones leaves `children: None` (libhex9 has no direct children
    enumeration), so the dggal-style children assertions are not reused.
  - `Hex9Impl::zone_ring(zone, densify)` is a Hex9-specific inherent method
    (outside the DggrsApi contract) for selecting ring densification, since
    DggrsApiConfig.densify is only a bool.
  - Whole-world deep enumerations are bounded by a cell ceiling
    (GRID_MAX_CELLS - default 100_000_000), which libhex9 enforces by bailing mid-enumeration.
