### PR TITLE
Fix regressed 1-based face indexing in Vgc::geo_to_cartesian

### DIFF
--- a/gp-proj/src/projections/projections/vgc.rs
+++ b/gp-proj/src/projections/projections/vgc.rs
@@ -153,7 +153,7 @@ impl Projection for Vgc {
                             x: p_x_face * r,
                             y: p_y_face * r,
                         },
-                        face: index + 1,
+                        face: index,
                     });
 
                     // in case the point is on the edge of two faces, we return the first face.


### PR DESCRIPTION
geo_to_cartesian set face: index + 1, breaking the 0-based convention used by are_faces_adjacent and the rest of gp-proj. Restores face: index, which fixes test_project_forward and test_pole_behavior without touching their assertions.

Closes issue #144 
Steps:
- [x] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [ ] Add README documentation of what's done in the PR, if needed.
- [x] Request review
