### PR TITLE
Fix maximum h3 resolution level

### DIFF
--- a/geoplegma/src/constants.rs
+++ b/geoplegma/src/constants.rs
@@ -51,7 +51,7 @@ pub const DGGRS_SPECS: [DggrsSpec; 11] = [
         crs: "",
         aperture: 7,
         min_refinement_level: RefinementLevel::new_const(0),
-        max_refinement_level: RefinementLevel::new_const(16),
+        max_refinement_level: RefinementLevel::new_const(15),
         default_refinement_level: RefinementLevel::new_const(2),
         max_relative_depth: RelativeDepth::new_const(6),
         default_relative_depth: RelativeDepth::new_const(4),


### PR DESCRIPTION
Corrected the maximum resolution level for H3 which is 15, not 16. 
https://h3geo.org/docs/core-library/restable/

Steps:
- [ ] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [x] Add README documentation of what's done in the PR, if needed.
- [x] Request review
