### PR TITLE
hex9-sys: pin libhex9 v2.1.0 (via-sphere regime, deterministic chain)

### DIFF
--- a/geoplegma/Cargo.toml
+++ b/geoplegma/Cargo.toml
@@ -22,7 +22,9 @@ tracing = "0.1.41"
 h3o = { version = "0.8.0", features = ["geo"] }
 dggal-rust = { git = "https://github.com/GeoPlegma/dggal-rust.git", branch = "dggal-0.0.6" }
 # libhex9 FFI bindings — the Hex9 / H9 DGGRS backend (the -sys crate lives at geoplegma/).
-hex9-sys = { git = "https://github.com/MrBenGriffin/libhex9", tag = "v1.0.0" }
+# v2.1.0: via-sphere regime (2.0.0) + sphere-datum twins + deterministic chain —
+# the same lon/lat yields the bit-identical uuid on every platform.
+hex9-sys = { git = "https://github.com/MrBenGriffin/libhex9", tag = "v2.1.0" }
 rayon = "1.10.0"
 thiserror = "2.0.12"
 once_cell = "1.21.0"
@@ -35,7 +37,7 @@ serde = ["dep:serde"]
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 # Direct FFI access in tests/hex9.rs to exercise libhex9's enumeration ceiling.
-hex9-sys = { git = "https://github.com/MrBenGriffin/libhex9", tag = "v1.0.0" }
+hex9-sys = { git = "https://github.com/MrBenGriffin/libhex9", tag = "v2.1.0" }
 
 [[bench]]
 name = "dggrs"

--- a/gp-bindings/js/Cargo.toml
+++ b/gp-bindings/js/Cargo.toml
@@ -12,8 +12,12 @@ crate-type = ["cdylib"]
 geo = "0.30.0"
 napi = "3.0.0"
 napi-derive = "3.0.0"
-# api = { path = "../../api" }   # depends on your core crate
-geoplegma = {git = "https://github.com/GeoPlegma/GeoPlegma.git", package = "geoplegma"}
+# Path, not git: as a workspace member this must build THIS tree's geoplegma
+# (gp-encoding already does the same). A git dependency on master resolves a
+# second copy of geoplegma — and two hex9-sys versions cannot coexist
+# (`links = "hex9"`), so any local change to that pin broke the whole
+# workspace resolve.
+geoplegma = { path = "../../geoplegma" }
 getrandom = { version = "0.2", features = ["js"] }
 
 [build-dependencies]


### PR DESCRIPTION
Pins `hex9-sys` to libhex9 **v2.1.0**. The previous pin, v1.0.0 (2026-06-23), predates libhex9's 2.0.0 via-sphere regime — addresses it mints differ from every current consumer's. No adapter changes: the merged adapter (#136) already targets the 2.x ABI.

**What v2.1.0 brings:**
- the 2.0.0 via-sphere regime (the only regime; the legacy WGS84 warp is gone),
- sphere-datum entry points (`*_sphere` twins) for callers with their own datum,
- a **deterministic encode chain**: the same lon/lat yields the bit-identical uuid (and space-filling-curve position) on every platform — vendored deterministic math kernels + pinned FP contraction, enforced by libhex9's CI across macOS/Linux/Windows including a strict cross-platform golden test.

**Also fixed here:** `gp-bindings/js` depended on `geoplegma` via a *git* dependency on this repo's master, resolving a second copy of the crate into the workspace graph. Two `hex9-sys` versions cannot coexist (`links = "hex9"`), so any change to the pin — including this one — failed the whole workspace resolve. It now uses a path dependency, matching `gp-encoding`.

**Windows note:** libhex9 cannot be built with MSVC (GNU-assembler `.incbin` data embed); WSL2 or the `x86_64-pc-windows-gnu` toolchain are the supported routes — see [libhex9's docs/building-on-windows.md](https://github.com/MrBenGriffin/libhex9/blob/main/docs/building-on-windows.md). The MinGW path is exercised by libhex9's CI.

Validated: fresh workspace resolve from the published tag; `cargo test` — hex9 integration tests 7/7 (the two `primary_parent_from_zone` dggrid failures are environmental — no `dggrid` binary — and exist on master; `example/basic.rs` also fails on master after the recent type-privacy refactor, untouched here).