### PR TITLE
Add python bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["geoplegma", "gp-bindings/js", "gp-encoding", "gp-proj", "viewer-3d/src-tauri"]
+members = ["geoplegma", "gp-bindings/js", "gp-bindings/python", "gp-encoding", "gp-proj", "viewer-3d/src-tauri"]
 exclude = ["tests", "diagrams", "docs"]
 resolver = "3"
 

--- a/gp-bindings/python/Cargo.toml
+++ b/gp-bindings/python/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "geoplegma-py"
+version = "0.2.1"
+edition = "2024"
+authors = ["GeoPlegma Developers"]
+description = "Python bindings for GeoPlegma (gp-encoding)"
+license = "MIT OR Apache-2.0"
+
+[lib]
+name = "geoplegma_py"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.20", features = ["extension-module", "abi3-py38"] }
+gp-encoding = { path = "../../gp-encoding" }
+geoplegma = { path = "../../geoplegma" }
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/gp-bindings/python/Cargo.toml
+++ b/gp-bindings/python/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "geoplegma-py"
-version = "0.2.1"
 edition = "2024"
 authors = ["GeoPlegma Developers"]
-description = "Python bindings for GeoPlegma (gp-encoding)"
+description = "Python bindings for GeoPlegma"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/gp-bindings/python/pyproject.toml
+++ b/gp-bindings/python/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["maturin>=1.4,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "geoplegma_py"
+requires-python = ">=3.8"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Python :: Implementation :: PyPy",
+]
+version = "0.2.1"
+description = "Python bindings for GeoPlegma"
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
+module-name = "geoplegma_py"

--- a/gp-bindings/python/src/lib.rs
+++ b/gp-bindings/python/src/lib.rs
@@ -1,0 +1,40 @@
+use pyo3::prelude::*;
+use pyo3::exceptions::PyRuntimeError;
+use std::path::Path;
+use gp_encoding::{StorageBackend, ZarrBackend};
+
+#[pyclass]
+pub struct Store {
+    backend: ZarrBackend,
+}
+
+#[pymethods]
+impl Store {
+    #[new]
+    fn new(path: String) -> PyResult<Self> {
+        let backend = ZarrBackend::open(Path::new(&path))
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to open store: {}", e)))?;
+        Ok(Store { backend })
+    }
+
+    fn levels(&self) -> PyResult<Vec<u32>> {
+        Ok(self.backend.levels())
+    }
+
+    fn export_level(&self, level: u32) -> PyResult<String> {
+        let cells = gp_encoding::query::export_level_as_visualization_json(&self.backend, level)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to export level: {}", e)))?;
+        
+        let json_str = serde_json::to_string(&cells)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to serialize to JSON: {}", e)))?;
+        
+        Ok(json_str)
+    }
+}
+
+/// A Python module implemented in Rust for GeoPlegma.
+#[pymodule]
+fn geoplegma_py(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<Store>()?;
+    Ok(())
+}

--- a/gp-bindings/python/src/lib.rs
+++ b/gp-bindings/python/src/lib.rs
@@ -21,14 +21,16 @@ impl Store {
         Ok(self.backend.levels())
     }
 
-    fn export_level(&self, level: u32) -> PyResult<String> {
-        let cells = gp_encoding::query::export_level_as_visualization_json(&self.backend, level)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to export level: {}", e)))?;
-        
-        let json_str = serde_json::to_string(&cells)
-            .map_err(|e| PyRuntimeError::new_err(format!("Failed to serialize to JSON: {}", e)))?;
-        
-        Ok(json_str)
+    fn export_level(&self, py: Python<'_>, level: u32) -> PyResult<String> {
+        py.allow_threads(|| {
+            let cells = gp_encoding::query::export_level_as_visualization_json(&self.backend, level)
+                .map_err(|e| PyRuntimeError::new_err(format!("Failed to export level: {}", e)))?;
+            
+            let json_str = serde_json::to_string(&cells)
+                .map_err(|e| PyRuntimeError::new_err(format!("Failed to serialize to JSON: {}", e)))?;
+            
+            Ok(json_str)
+        })
     }
 }
 


### PR DESCRIPTION
In order to support [GeoPlegma/gp-qgis-plugin](https://github.com/GeoPlegma/gp-qgis-plugin), I've added very simple python bindings using PyO3. For now, only the necessary functions for the QGIS plugin were added, but more could be added in the future.

Steps:
- [ ] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [x] Add README documentation of what's done in the PR, if needed.
- [x] Request review
