### PR TITLE
Detect fill value from input raster

### DIFF
--- a/gp-encoding/src/convert.rs
+++ b/gp-encoding/src/convert.rs
@@ -74,7 +74,10 @@ fn attribute_schema_from_band(band: &RasterBand<'_>) -> Result<AttributeSchema, 
 
     Ok(AttributeSchema {
         dtype,
-        fill_value: band.no_data_value().map(|value| value.to_string()),
+        fill_value: band
+            .no_data_value()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| dtype.default_fill_value()),
     })
 }
 
@@ -570,10 +573,7 @@ where
         .attributes
         .iter()
         .map(|attr| {
-            let fill_val = match &attr.fill_value {
-                Some(value) => parse_fill_value_to_f64(&attr.dtype, value)?,
-                None => 0.0,
-            };
+            let fill_val = parse_fill_value_to_f64(&attr.dtype, &attr.fill_value)?;
             encode_value_from_f64(&attr.dtype, fill_val)
         })
         .collect::<Result<_, EncodingError>>()?;
@@ -978,10 +978,7 @@ where
             .attributes
             .iter()
             .map(|attr| {
-                let fill_val = match &attr.fill_value {
-                    Some(value) => parse_fill_value_to_f64(&attr.dtype, value)?,
-                    None => 0.0,
-                };
+                let fill_val = parse_fill_value_to_f64(&attr.dtype, &attr.fill_value)?;
                 encode_value_from_f64(&attr.dtype, fill_val)
             })
             .collect::<Result<_, EncodingError>>()?;
@@ -1133,6 +1130,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gdal::DriverManager;
     use std::time::{SystemTime, UNIX_EPOCH};
     use std::path::PathBuf;
     use crate::zarr::ZarrBackend;
@@ -1144,6 +1142,33 @@ mod tests {
             .expect("system time")
             .as_nanos();
         std::env::temp_dir().join(format!("gp_encoding_{name}_{nanos}"))
+    }
+
+    #[test]
+    fn test_attribute_schema_uses_declared_no_data() {
+        let driver = DriverManager::get_driver_by_name("MEM").expect("MEM driver");
+        let dataset = driver
+            .create_with_band_type::<f32, _>("", 1, 1, 1)
+            .expect("create in-memory raster");
+        let mut band = dataset.rasterband(1).expect("raster band");
+        band.set_no_data_value(Some(-9999.0)).expect("set no-data");
+
+        let schema = attribute_schema_from_band(&band).expect("attribute schema");
+
+        assert_eq!(schema.fill_value, "-9999");
+    }
+
+    #[test]
+    fn test_attribute_schema_uses_default_when_no_data_is_missing() {
+        let driver = DriverManager::get_driver_by_name("MEM").expect("MEM driver");
+        let dataset = driver
+            .create_with_band_type::<f32, _>("", 1, 1, 1)
+            .expect("create in-memory raster");
+        let band = dataset.rasterband(1).expect("raster band");
+
+        let schema = attribute_schema_from_band(&band).expect("attribute schema");
+
+        assert_eq!(schema.fill_value, "NaN");
     }
 
     #[test]
@@ -1177,7 +1202,7 @@ mod tests {
             dggrs: dggrs_src,
             attributes: vec![AttributeSchema {
                 dtype: DataType::Float32,
-                fill_value: Some("0.0".to_string()),
+                fill_value: "0.0".to_string(),
             }],
             chunk_size: src_chunk_size,
             levels: vec![src_refinement_level.get() as u32],
@@ -1246,4 +1271,3 @@ mod tests {
         assert_eq!(get_subdataset_short_name("HDF5:file.h5:variable_with_spaces "), "variable_with_spaces");
     }
 }
-

--- a/gp-encoding/src/convert.rs
+++ b/gp-encoding/src/convert.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::str::FromStr;
 
-use gdal::raster::GdalDataType;
+use gdal::raster::{GdalDataType, RasterBand};
 use gdal::spatial_ref::{CoordTransform, SpatialRef};
 use gdal::{Dataset, GeoTransformEx, Metadata};
 use geoplegma::api::DggrsApiConfig;
@@ -51,6 +51,32 @@ macro_rules! impl_native_bytes {
 impl_native_bytes!(u8, i8, u16, i16, u32, i32, u64, i64, f32, f64);
 
 const ZARR_TARGET_UNCOMPRESSED_CHUNK_BYTES: u64 = 1024 * 1024;
+
+fn attribute_schema_from_band(band: &RasterBand<'_>) -> Result<AttributeSchema, EncodingError> {
+    let band_type = band.band_type();
+    let dtype = match band_type {
+        GdalDataType::UInt8 => DataType::UInt8,
+        GdalDataType::Int8 => DataType::Int8,
+        GdalDataType::Int16 => DataType::Int16,
+        GdalDataType::UInt16 => DataType::UInt16,
+        GdalDataType::Int32 => DataType::Int32,
+        GdalDataType::UInt32 => DataType::UInt32,
+        GdalDataType::Int64 => DataType::Int64,
+        GdalDataType::UInt64 => DataType::UInt64,
+        GdalDataType::Float32 => DataType::Float32,
+        GdalDataType::Float64 => DataType::Float64,
+        _ => {
+            return Err(EncodingError::Dataset(format!(
+                "unsupported GDAL data type: {band_type:?}"
+            )));
+        }
+    };
+
+    Ok(AttributeSchema {
+        dtype,
+        fill_value: band.no_data_value().map(|value| value.to_string()),
+    })
+}
 
 fn get_corners_and_pixel_size(
     dataset: &Dataset,
@@ -428,32 +454,9 @@ where
         .rasterbands()
         .map(|b| b.map(|band| band.band_type()))
         .collect::<Result<Vec<_>, _>>()?;
-    let metadata_bands = bands
-        .iter()
-        .map(|band_type| {
-            let dtype = match band_type {
-                GdalDataType::UInt8 => DataType::UInt8,
-                GdalDataType::Int8 => DataType::Int8,
-                GdalDataType::Int16 => DataType::Int16,
-                GdalDataType::UInt16 => DataType::UInt16,
-                GdalDataType::Int32 => DataType::Int32,
-                GdalDataType::UInt32 => DataType::UInt32,
-                GdalDataType::Int64 => DataType::Int64,
-                GdalDataType::UInt64 => DataType::UInt64,
-                GdalDataType::Float32 => DataType::Float32,
-                GdalDataType::Float64 => DataType::Float64,
-                _ => {
-                    return Err(EncodingError::Dataset(format!(
-                        "unsupported GDAL data type: {band_type:?}"
-                    )));
-                }
-            };
-
-            Ok(AttributeSchema {
-                dtype,
-                fill_value: Some("0.0".to_string()),
-            })
-        })
+    let metadata_bands = dataset
+        .rasterbands()
+        .map(|band| attribute_schema_from_band(&band?))
         .collect::<Result<Vec<_>, EncodingError>>()?;
 
     if metadata_bands.is_empty() {
@@ -1243,5 +1246,4 @@ mod tests {
         assert_eq!(get_subdataset_short_name("HDF5:file.h5:variable_with_spaces "), "variable_with_spaces");
     }
 }
-
 

--- a/gp-encoding/src/models.rs
+++ b/gp-encoding/src/models.rs
@@ -43,8 +43,8 @@ pub struct AttributeSchema {
     /// Data type of the attribute values.
     pub dtype: DataType,
 
-    /// Optional fill / no-data value.
-    pub fill_value: Option<String>,
+    /// Fill / no-data value.
+    pub fill_value: String,
 }
 
 /// Supported data types for cell attribute values.
@@ -69,6 +69,20 @@ impl DataType {
             DataType::Int16 | DataType::UInt16 => 2,
             DataType::Float32 | DataType::Int32 | DataType::UInt32 => 4,
             DataType::Float64 | DataType::Int64 | DataType::UInt64 => 8,
+        }
+    }
+
+    pub fn default_fill_value(&self) -> String {
+        match self {
+            DataType::Float32 | DataType::Float64 => "NaN".to_string(),
+            DataType::Int8 => i8::MIN.to_string(),
+            DataType::Int16 => i16::MIN.to_string(),
+            DataType::Int32 => i32::MIN.to_string(),
+            DataType::Int64 => i64::MIN.to_string(),
+            DataType::UInt8 => u8::MAX.to_string(),
+            DataType::UInt16 => u16::MAX.to_string(),
+            DataType::UInt32 => u32::MAX.to_string(),
+            DataType::UInt64 => u64::MAX.to_string(),
         }
     }
 }

--- a/gp-encoding/src/query.rs
+++ b/gp-encoding/src/query.rs
@@ -20,9 +20,11 @@ use serde_json::Value;
 use crate::common::{CENTER_CONFIG, ID_ONLY_CONFIG};
 use crate::error::EncodingError;
 use crate::storage::StorageBackend;
-use crate::value::{
-    decode_value_to_f64, decode_value_to_json, parse_fill_value_to_f64, parse_fill_value_to_json,
-};
+use crate::value::{decode_value_to_f64, decode_value_to_json, parse_fill_value_to_f64};
+
+fn is_fill_value(value: f64, fill_value: f64) -> bool {
+    value == fill_value || (value.is_nan() && fill_value.is_nan())
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct VisualizationCell {
@@ -262,17 +264,11 @@ where
     let grid = get(backend.metadata().dggrs)
         .map_err(|e| EncodingError::Grid(format!("failed to resolve DGGS: {e}")))?;
 
-    let fill_values: Vec<Option<Value>> = backend
+    let fill_values: Vec<f64> = backend
         .metadata()
         .attributes
         .iter()
-        .map(|attr| {
-            if let Some(fill_value) = &attr.fill_value {
-                Ok(Some(parse_fill_value_to_json(&attr.dtype, fill_value)?))
-            } else {
-                Ok(None)
-            }
-        })
+        .map(|attr| parse_fill_value_to_f64(&attr.dtype, &attr.fill_value))
         .collect::<Result<_, EncodingError>>()?;
 
     let mut row_count = 0_usize;
@@ -318,13 +314,12 @@ where
                     )));
                 }
 
-                let value = decode_value_to_json(dtype, &chunk[start..end])?;
-                if fill_values[band as usize]
-                    .as_ref()
-                    .is_some_and(|fill_value| *fill_value == value)
-                {
+                let value_bytes = &chunk[start..end];
+                let numeric_value = decode_value_to_f64(dtype, value_bytes)?;
+                if is_fill_value(numeric_value, fill_values[band as usize]) {
                     continue;
                 }
+                let value = decode_value_to_json(dtype, value_bytes)?;
                 bands.insert(format!("band_{band}"), value);
                 has_non_fill = true;
             }
@@ -385,17 +380,11 @@ where
     let grid = get(backend.metadata().dggrs)
         .map_err(|e| EncodingError::Grid(format!("failed to resolve DGGS: {e}")))?;
 
-    let fill_values: Vec<Option<f64>> = backend
+    let fill_values: Vec<f64> = backend
         .metadata()
         .attributes
         .iter()
-        .map(|attr| {
-            if let Some(fill_value) = &attr.fill_value {
-                Ok(Some(parse_fill_value_to_f64(&attr.dtype, fill_value)?))
-            } else {
-                Ok(None)
-            }
-        })
+        .map(|attr| parse_fill_value_to_f64(&attr.dtype, &attr.fill_value))
         .collect::<Result<_, EncodingError>>()?;
 
     let mut row_count = 0_usize;
@@ -472,10 +461,7 @@ where
                 }
 
                 let value = decode_value_to_f64(dtype, &chunk[start..end])?;
-                if fill_values[band as usize]
-                    .as_ref()
-                    .is_some_and(|fill_value| *fill_value == value)
-                {
+                if is_fill_value(value, fill_values[band as usize]) {
                     continue;
                 }
 
@@ -510,7 +496,7 @@ mod tests {
 
     use crate::common::ID_ONLY_CONFIG;
     use crate::models::{AttributeSchema, DataType, DatasetMetadata};
-    use crate::query::query_value_by_cell_index;
+    use crate::query::{is_fill_value, query_value_by_cell_index};
     use crate::storage::StorageBackend;
     use crate::zarr::ZarrBackend;
 
@@ -520,6 +506,12 @@ mod tests {
             .expect("system time")
             .as_nanos();
         std::env::temp_dir().join(format!("gp_encoding_{name}_{nanos}"))
+    }
+
+    #[test]
+    fn nan_values_match_nan_fill() {
+        assert!(is_fill_value(f64::NAN, f64::NAN));
+        assert!(!is_fill_value(1.0, f64::NAN));
     }
 
     #[test]
@@ -567,7 +559,7 @@ mod tests {
             dggrs,
             attributes: vec![AttributeSchema {
                 dtype: DataType::UInt16,
-                fill_value: None,
+                fill_value: u16::MAX.to_string(),
             }],
             chunk_size,
             levels: vec![refinement_level.get() as u32],
@@ -585,6 +577,15 @@ mod tests {
         backend
             .create_level(refinement_level.get() as u32, 0, 2 * chunk_size, chunk_size)
             .expect("create level");
+
+        let array_metadata: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(
+                store_path.join(format!("level_{}/band_0/zarr.json", refinement_level.get())),
+            )
+            .expect("read array metadata"),
+        )
+        .expect("parse array metadata");
+        assert_eq!(array_metadata["fill_value"], serde_json::json!(u16::MAX));
 
         let mut chunk0_values = vec![0_u16; chunk_size as usize];
         chunk0_values[0] = 10;

--- a/gp-encoding/src/value.rs
+++ b/gp-encoding/src/value.rs
@@ -123,45 +123,6 @@ pub fn encode_value_from_f64(dtype: &DataType, value: f64) -> Result<Vec<u8>, En
     Ok(bytes)
 }
 
-pub fn parse_fill_value_to_json(
-    dtype: &DataType,
-    fill_value: &str,
-) -> Result<Value, EncodingError> {
-    let trimmed = fill_value.trim();
-    match dtype {
-        DataType::Float32 | DataType::Float64 => {
-            let value = trimmed.parse::<f64>().map_err(|e| {
-                EncodingError::Storage(format!("invalid fill value '{fill_value}': {e}"))
-            })?;
-            Number::from_f64(value).map(Value::Number).ok_or_else(|| {
-                EncodingError::Storage(format!(
-                    "cannot represent fill value {value} as JSON number"
-                ))
-            })
-        }
-        DataType::Int8 => parse_i64_in_range(trimmed, i8::MIN as i64, i8::MAX as i64)
-            .map(|value| Value::Number(value.into())),
-        DataType::Int16 => parse_i64_in_range(trimmed, i16::MIN as i64, i16::MAX as i64)
-            .map(|value| Value::Number(value.into())),
-        DataType::Int32 => parse_i64_in_range(trimmed, i32::MIN as i64, i32::MAX as i64)
-            .map(|value| Value::Number(value.into())),
-        DataType::Int64 => {
-            parse_i64_in_range(trimmed, i64::MIN, i64::MAX).map(|value| Value::Number(value.into()))
-        }
-        DataType::UInt8 => {
-            parse_u64_in_range(trimmed, u8::MAX as u64).map(|value| Value::Number(value.into()))
-        }
-        DataType::UInt16 => {
-            parse_u64_in_range(trimmed, u16::MAX as u64).map(|value| Value::Number(value.into()))
-        }
-        DataType::UInt32 => {
-            parse_u64_in_range(trimmed, u32::MAX as u64).map(|value| Value::Number(value.into()))
-        }
-        DataType::UInt64 => {
-            parse_u64_in_range(trimmed, u64::MAX).map(|value| Value::Number(value.into()))
-        }
-    }
-}
 
 pub fn format_value(dtype: &DataType, bytes: &[u8]) -> Result<String, EncodingError> {
     decode_value_to_json(dtype, bytes).map(|value| value.to_string())

--- a/gp-encoding/src/zarr.rs
+++ b/gp-encoding/src/zarr.rs
@@ -18,7 +18,7 @@ use geoplegma::types::{RefinementLevel, RelativeDepth, ZoneId};
 use indicatif::{ProgressBar, ProgressStyle};
 use zarrs::array::codec::api::BytesToBytesCodecTraits;
 use zarrs::array::codec::{GzipCodec, ZstdCodec};
-use zarrs::array::{Array, ArrayBuilder, ArrayBytes};
+use zarrs::array::{Array, ArrayBuilder, ArrayBytes, FillValue};
 use zarrs::group::{Group, GroupBuilder};
 use zarrs_filesystem::FilesystemStore;
 
@@ -85,14 +85,6 @@ impl ZarrBackend {
             DataType::UInt32 => "uint32",
             DataType::UInt64 => "uint64",
         }
-    }
-
-    fn primary_dtype_str(&self) -> &'static str {
-        self.metadata
-            .attributes
-            .first()
-            .map(|a| Self::to_zarr_dtype_str(&a.dtype))
-            .unwrap_or("uint64")
     }
 
     fn level_path(level: u32, band: u32) -> String {
@@ -310,16 +302,11 @@ impl ZarrBackend {
         let source_relative_depth =
             RelativeDepth::new(source_level_i32 - source_chunk_level.get())?;
         let level_steps = source_level_i32 - target_level_i32;
-        let fill_values: Vec<Option<f64>> = self
+        let fill_values: Vec<f64> = self
             .metadata
             .attributes
             .iter()
-            .map(|attr| {
-                attr.fill_value
-                    .as_ref()
-                    .map(|value| parse_fill_value_to_f64(&attr.dtype, value))
-                    .transpose()
-            })
+            .map(|attr| parse_fill_value_to_f64(&attr.dtype, &attr.fill_value))
             .collect::<Result<_, EncodingError>>()?;
 
         self.set_level_chunk_ids(target_level, target_chunk_level.get() as u32, target_chunk_ids.clone())?;
@@ -337,10 +324,7 @@ impl ZarrBackend {
             .attributes
             .iter()
             .map(|attr| {
-                let fill_value = match &attr.fill_value {
-                    Some(value) => parse_fill_value_to_f64(&attr.dtype, value)?,
-                    None => 0.0,
-                };
+                let fill_value = parse_fill_value_to_f64(&attr.dtype, &attr.fill_value)?;
                 encode_value_from_f64(&attr.dtype, fill_value)
             })
             .collect::<Result<_, EncodingError>>()?;
@@ -423,7 +407,9 @@ impl ZarrBackend {
                                     }
 
                                     let value = decode_value_to_f64(dtype, &chunk[start..end])?;
-                                    if fill_values[band].is_some_and(|fill_value| fill_value == value) {
+                                    if value == fill_values[band]
+                                        || (value.is_nan() && fill_values[band].is_nan())
+                                    {
                                         continue;
                                     }
 
@@ -562,13 +548,18 @@ impl StorageBackend for ZarrBackend {
         chunk_size: u64,
     ) -> Result<ZarrLevel, EncodingError> {
         let path = Self::level_path(level, band);
-        let dtype_str = self.primary_dtype_str();
+        let attribute = self.metadata.attributes.get(band as usize).ok_or_else(|| {
+            EncodingError::Storage(format!("band {band} is not present in dataset metadata"))
+        })?;
+        let dtype_str = Self::to_zarr_dtype_str(&attribute.dtype);
+        let fill_value = parse_fill_value_to_f64(&attribute.dtype, &attribute.fill_value)?;
+        let fill_bytes = encode_value_from_f64(&attribute.dtype, fill_value)?;
 
         let mut array_builder = ArrayBuilder::new(
             vec![num_cells],
             vec![chunk_size],
             dtype_str,
-            0u64,
+            FillValue::new(fill_bytes),
         );
 
         if let Some(codecs) = Self::codecs_for_compression(self.metadata.compression.as_ref())? {


### PR DESCRIPTION
In `gp-encoding`, the fill/NoData value was still hard coded to 0 regardless of the original data. This PR fixes it by first detecting what is the fill value defined in the input raster, and if it is null, it defaults to an appropriate value depending on the data type of the raster.

Steps:
- [ ] Link PR to the issue or kanban board item.
- [x] Write a list of what was done, preferably by bullet points.
- [ ] Add README documentation of what's done in the PR, if needed.
- [x] Request review
